### PR TITLE
docs: enforce pull request workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,10 @@ OCR quality, image preprocessing, and bottle matching precision can be improved 
 
 - Do not commit directly to `main`.
 - Create a feature branch for every change.
+- Do not push implementation or documentation changes directly to `main`.
+- Do not merge a working branch into `main` before a Pull Request is created.
+- Create a Pull Request after implementation is complete.
+- Wait for explicit user confirmation before merging any Pull Request.
 - Use descriptive branch names.
   - Feature work: `feature/...`
   - Documentation work: `docs/...`
@@ -86,6 +90,10 @@ Examples:
 ## Pull Request Rules
 
 Every PR should target `main` unless the user explicitly says otherwise.
+
+Pull Requests are mandatory for all changes. Even when the user asks to
+"merge to main" or "push to main", first create a working branch and Pull
+Request, then wait for the user's confirmation before merging.
 
 Every PR description should include:
 


### PR DESCRIPTION
## Summary

Codifies the workflow guardrails so Codex does not commit, push, or merge changes directly to `main` before a Pull Request is created and confirmed by the user.

## What changed

- Updated `AGENTS.md` development rules to explicitly prohibit direct pushes to `main` and pre-PR merges.
- Updated Pull Request rules to require a PR for all changes, even when the user asks to merge or push to `main`.
- Added an explicit requirement to wait for user confirmation before merging.

## Validation

- Documentation-only change; no build or tests required.
- Confirmed the change was committed on branch `docs-enforce-pr-workflow` and pushed to origin.

## Screenshot

N/A