### PR TITLE
fix(frontend): support Vercel Google Vision credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,11 @@ NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 INTERNAL_API_BASE_URL=http://backend:8000
 
 # Google Vision OCR
-# Option 1: path to a service account JSON file
-GOOGLE_APPLICATION_CREDENTIALS=
-# Option 2: raw service account JSON string
+# Vercel: set GOOGLE_APPLICATION_CREDENTIALS_JSON to the raw service account JSON.
 GOOGLE_APPLICATION_CREDENTIALS_JSON=
-# Option 3: individual service account fields
+# Local only: path to a service account JSON file for Application Default Credentials.
+GOOGLE_APPLICATION_CREDENTIALS=
+# Optional fallback: individual service account fields.
 GOOGLE_CLOUD_PROJECT=
 GOOGLE_CLOUD_CLIENT_EMAIL=
 GOOGLE_CLOUD_PRIVATE_KEY=

--- a/README.md
+++ b/README.md
@@ -96,6 +96,34 @@ npm run dev
 npm run build
 ```
 
+## Vercel Deployment
+
+Deploy the Next.js frontend from the `frontend/` directory.
+
+Required Vercel project settings:
+
+- Framework Preset: Next.js
+- Root Directory: `frontend`
+- Build Command: `npm run build`
+- Install Command: `npm install`
+
+Set these Vercel Environment Variables:
+
+- `GOOGLE_APPLICATION_CREDENTIALS_JSON`
+  - Required for Google Vision OCR on Vercel.
+  - Paste the full service account JSON as a single environment variable value.
+  - The JSON must include `client_email`, `private_key`, and `project_id`.
+- `GOOGLE_CLOUD_PROJECT`
+  - Optional when `project_id` is included in `GOOGLE_APPLICATION_CREDENTIALS_JSON`.
+  - Use this to override the project id if needed.
+
+Optional fallback variables:
+
+- `GOOGLE_CLOUD_CLIENT_EMAIL`
+- `GOOGLE_CLOUD_PRIVATE_KEY`
+
+Do not rely on `GOOGLE_APPLICATION_CREDENTIALS` or a local `key.json` file in Vercel. The OCR API route uses `GOOGLE_APPLICATION_CREDENTIALS_JSON` first, so Google Vision authentication can run from Vercel Environment Variables only.
+
 ## Backend Endpoints
 
 - `GET /health`

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -67,6 +67,34 @@ Open:
 - Frontend: http://localhost:3000
 - Backend health: http://localhost:8000/health
 
+## Vercel Deployment Notes
+
+Deploy the frontend as a Vercel project with `frontend/` as the Root Directory.
+
+Vercel project settings:
+
+- Framework Preset: Next.js
+- Root Directory: `frontend`
+- Build Command: `npm run build`
+- Install Command: `npm install`
+
+Google Vision OCR authentication should use Environment Variables only in Vercel:
+
+- `GOOGLE_APPLICATION_CREDENTIALS_JSON`
+  - Required and preferred.
+  - Paste the full service account JSON value.
+  - Must include `client_email`, `private_key`, and `project_id`.
+- `GOOGLE_CLOUD_PROJECT`
+  - Optional if the JSON already includes `project_id`.
+  - Use only when overriding the Google Cloud project is necessary.
+
+Optional fallback variables:
+
+- `GOOGLE_CLOUD_CLIENT_EMAIL`
+- `GOOGLE_CLOUD_PRIVATE_KEY`
+
+Do not configure Vercel OCR with `GOOGLE_APPLICATION_CREDENTIALS` or a local `key.json` path. Vercel does not provide that local credential file, and `frontend/app/api/ocr/route.ts` now requires JSON or explicit service account fields when running in Vercel.
+
 ## Validation Checklist
 
 For documentation-only changes:

--- a/frontend/app/api/ocr/route.ts
+++ b/frontend/app/api/ocr/route.ts
@@ -13,6 +13,30 @@ type OcrErrorResponse = {
 
 let visionClient: ImageAnnotatorClient | null = null;
 
+function parseCredentialsJson(credentialsJson: string) {
+  try {
+    const credentials = JSON.parse(credentialsJson) as {
+      client_email?: string;
+      private_key?: string;
+      project_id?: string;
+    };
+
+    if (!credentials.client_email || !credentials.private_key) {
+      throw new Error(
+        "GOOGLE_APPLICATION_CREDENTIALS_JSON must include client_email and private_key.",
+      );
+    }
+
+    return credentials;
+  } catch (error) {
+    throw new Error(
+      `Invalid GOOGLE_APPLICATION_CREDENTIALS_JSON: ${
+        error instanceof Error ? error.message : "unknown parse error"
+      }`,
+    );
+  }
+}
+
 function getVisionClient() {
   if (visionClient) {
     return visionClient;
@@ -22,12 +46,15 @@ function getVisionClient() {
   const clientEmail = process.env.GOOGLE_CLOUD_CLIENT_EMAIL;
   const privateKey = process.env.GOOGLE_CLOUD_PRIVATE_KEY?.replace(/\\n/g, "\n");
   const projectId = process.env.GOOGLE_CLOUD_PROJECT;
+  const isVercel = Boolean(process.env.VERCEL || process.env.VERCEL_ENV);
 
   if (credentialsJson) {
+    const credentials = parseCredentialsJson(credentialsJson);
+
     visionClient = new ImageAnnotatorClient({
-      credentials: JSON.parse(credentialsJson),
+      credentials,
       fallback: true,
-      projectId,
+      projectId: projectId ?? credentials.project_id,
     });
     return visionClient;
   }
@@ -42,6 +69,12 @@ function getVisionClient() {
       projectId,
     });
     return visionClient;
+  }
+
+  if (isVercel) {
+    throw new Error(
+      "Google Vision OCR requires GOOGLE_APPLICATION_CREDENTIALS_JSON or GOOGLE_CLOUD_CLIENT_EMAIL/GOOGLE_CLOUD_PRIVATE_KEY in Vercel.",
+    );
   }
 
   visionClient = new ImageAnnotatorClient({ fallback: true, projectId });


### PR DESCRIPTION
## Summary

Closes #23. Make Google Vision OCR authentication work on Vercel using Environment Variables only.

## What changed

- Prioritize GOOGLE_APPLICATION_CREDENTIALS_JSON in frontend/app/api/ocr/route.ts and validate required service account fields.
- Prevent Vercel from falling back to local file-based Application Default Credentials when env credentials are missing.
- Document Vercel project settings and Google Vision Environment Variables in README.md and docs/HANDOFF.md.
- Clarify .env.example guidance for Vercel and local-only credential paths.

## Validation

- npm run build from frontend/ passed.

## Screenshot

N/A