### PR TITLE
fix(frontend): improve Vercel OCR diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Set these Vercel Environment Variables:
   - Required for Google Vision OCR on Vercel.
   - Paste the full service account JSON as a single environment variable value.
   - The JSON must include `client_email`, `private_key`, and `project_id`.
+  - If `private_key` contains escaped `\n` sequences, the OCR API normalizes them before calling Google Vision.
 - `GOOGLE_CLOUD_PROJECT`
   - Optional when `project_id` is included in `GOOGLE_APPLICATION_CREDENTIALS_JSON`.
   - Use this to override the project id if needed.
@@ -123,6 +124,8 @@ Optional fallback variables:
 - `GOOGLE_CLOUD_PRIVATE_KEY`
 
 Do not rely on `GOOGLE_APPLICATION_CREDENTIALS` or a local `key.json` file in Vercel. The OCR API route uses `GOOGLE_APPLICATION_CREDENTIALS_JSON` first, so Google Vision authentication can run from Vercel Environment Variables only.
+
+When OCR fails on Vercel, check Function Logs for entries prefixed with `[OCR]`. The logs report the selected credential source and private key format flags without printing secret values.
 
 ## Backend Endpoints
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -84,6 +84,7 @@ Google Vision OCR authentication should use Environment Variables only in Vercel
   - Required and preferred.
   - Paste the full service account JSON value.
   - Must include `client_email`, `private_key`, and `project_id`.
+  - Escaped `\n` sequences in `private_key` are normalized by the OCR API route.
 - `GOOGLE_CLOUD_PROJECT`
   - Optional if the JSON already includes `project_id`.
   - Use only when overriding the Google Cloud project is necessary.
@@ -94,6 +95,8 @@ Optional fallback variables:
 - `GOOGLE_CLOUD_PRIVATE_KEY`
 
 Do not configure Vercel OCR with `GOOGLE_APPLICATION_CREDENTIALS` or a local `key.json` path. Vercel does not provide that local credential file, and `frontend/app/api/ocr/route.ts` now requires JSON or explicit service account fields when running in Vercel.
+
+For OCR failures on Vercel, inspect Function Logs for `[OCR]` entries. They include the credential source and private key format flags, but do not print credential values.
 
 ## Validation Checklist
 

--- a/frontend/app/api/ocr/route.ts
+++ b/frontend/app/api/ocr/route.ts
@@ -2,20 +2,69 @@ import { ImageAnnotatorClient } from "@google-cloud/vision";
 import { NextResponse } from "next/server";
 
 export const runtime = "nodejs";
+export const maxDuration = 30;
 
 type OcrSuccessResponse = {
   text: string;
 };
 
+type OcrErrorCode =
+  | "invalid_request"
+  | "vision_auth_failed"
+  | "vision_config_missing"
+  | "vision_config_invalid"
+  | "vision_permission_denied"
+  | "vision_request_failed";
+
 type OcrErrorResponse = {
   error: string;
+  code?: OcrErrorCode;
+  details?: string;
 };
 
 let visionClient: ImageAnnotatorClient | null = null;
 
+class OcrConfigError extends Error {
+  constructor(
+    message: string,
+    readonly code: OcrErrorCode,
+  ) {
+    super(message);
+    this.name = "OcrConfigError";
+  }
+}
+
+function normalizePrivateKey(privateKey: string) {
+  return privateKey.replace(/\\n/g, "\n");
+}
+
+function getPrivateKeyFormat(privateKey?: string) {
+  return {
+    hasValue: Boolean(privateKey),
+    hasBeginMarker: Boolean(privateKey?.includes("-----BEGIN PRIVATE KEY-----")),
+    hasEndMarker: Boolean(privateKey?.includes("-----END PRIVATE KEY-----")),
+    hasEscapedNewlines: Boolean(privateKey?.includes("\\n")),
+    hasActualNewlines: Boolean(privateKey?.includes("\n")),
+  };
+}
+
+function logOcrEnvironment(source: string, privateKey?: string) {
+  console.info("[OCR] Google Vision credential source:", {
+    source,
+    isVercel: Boolean(process.env.VERCEL || process.env.VERCEL_ENV),
+    hasCredentialsJson: Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON),
+    hasClientEmail: Boolean(process.env.GOOGLE_CLOUD_CLIENT_EMAIL),
+    hasProjectId: Boolean(process.env.GOOGLE_CLOUD_PROJECT),
+    privateKeyFormat: getPrivateKeyFormat(privateKey),
+  });
+}
+
 function parseCredentialsJson(credentialsJson: string) {
   try {
-    const credentials = JSON.parse(credentialsJson) as {
+    const parsed = JSON.parse(credentialsJson) as unknown;
+    const credentials = (
+      typeof parsed === "string" ? JSON.parse(parsed) : parsed
+    ) as {
       client_email?: string;
       private_key?: string;
       project_id?: string;
@@ -27,12 +76,16 @@ function parseCredentialsJson(credentialsJson: string) {
       );
     }
 
-    return credentials;
+    return {
+      ...credentials,
+      private_key: normalizePrivateKey(credentials.private_key),
+    };
   } catch (error) {
-    throw new Error(
+    throw new OcrConfigError(
       `Invalid GOOGLE_APPLICATION_CREDENTIALS_JSON: ${
         error instanceof Error ? error.message : "unknown parse error"
       }`,
+      "vision_config_invalid",
     );
   }
 }
@@ -44,12 +97,15 @@ function getVisionClient() {
 
   const credentialsJson = process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON;
   const clientEmail = process.env.GOOGLE_CLOUD_CLIENT_EMAIL;
-  const privateKey = process.env.GOOGLE_CLOUD_PRIVATE_KEY?.replace(/\\n/g, "\n");
+  const privateKey = process.env.GOOGLE_CLOUD_PRIVATE_KEY
+    ? normalizePrivateKey(process.env.GOOGLE_CLOUD_PRIVATE_KEY)
+    : undefined;
   const projectId = process.env.GOOGLE_CLOUD_PROJECT;
   const isVercel = Boolean(process.env.VERCEL || process.env.VERCEL_ENV);
 
   if (credentialsJson) {
     const credentials = parseCredentialsJson(credentialsJson);
+    logOcrEnvironment("GOOGLE_APPLICATION_CREDENTIALS_JSON", credentials.private_key);
 
     visionClient = new ImageAnnotatorClient({
       credentials,
@@ -60,6 +116,8 @@ function getVisionClient() {
   }
 
   if (clientEmail && privateKey) {
+    logOcrEnvironment("GOOGLE_CLOUD_CLIENT_EMAIL/GOOGLE_CLOUD_PRIVATE_KEY", privateKey);
+
     visionClient = new ImageAnnotatorClient({
       credentials: {
         client_email: clientEmail,
@@ -72,17 +130,73 @@ function getVisionClient() {
   }
 
   if (isVercel) {
-    throw new Error(
+    logOcrEnvironment("missing", privateKey);
+    throw new OcrConfigError(
       "Google Vision OCR requires GOOGLE_APPLICATION_CREDENTIALS_JSON or GOOGLE_CLOUD_CLIENT_EMAIL/GOOGLE_CLOUD_PRIVATE_KEY in Vercel.",
+      "vision_config_missing",
     );
   }
 
+  logOcrEnvironment("application_default_credentials", privateKey);
   visionClient = new ImageAnnotatorClient({ fallback: true, projectId });
   return visionClient;
 }
 
-function jsonError(message: string, status: number) {
-  return NextResponse.json<OcrErrorResponse>({ error: message }, { status });
+function jsonError(
+  message: string,
+  status: number,
+  code?: OcrErrorCode,
+  details?: string,
+) {
+  const safeMessage = details ? `${message} ${details}` : message;
+
+  return NextResponse.json<OcrErrorResponse>(
+    { error: safeMessage, code, details },
+    { status },
+  );
+}
+
+function classifyOcrError(error: unknown): {
+  code: OcrErrorCode;
+  details: string;
+} {
+  if (error instanceof OcrConfigError) {
+    return { code: error.code, details: error.message };
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  const lowerMessage = message.toLowerCase();
+
+  if (
+    lowerMessage.includes("private key") ||
+    lowerMessage.includes("pem") ||
+    lowerMessage.includes("credential") ||
+    lowerMessage.includes("authentication") ||
+    lowerMessage.includes("invalid_grant")
+  ) {
+    return {
+      code: "vision_auth_failed",
+      details:
+        "Google Vision authentication failed. Check the Vercel service account JSON and private_key newline formatting.",
+    };
+  }
+
+  if (
+    lowerMessage.includes("permission_denied") ||
+    lowerMessage.includes("permission denied")
+  ) {
+    return {
+      code: "vision_permission_denied",
+      details:
+        "Google Vision rejected the request. Check that the Vision API is enabled and the service account has access.",
+    };
+  }
+
+  return {
+    code: "vision_request_failed",
+    details:
+      "Google Vision request failed. Check Vercel Function Logs for the safe OCR diagnostic entry.",
+  };
 }
 
 export async function POST(request: Request) {
@@ -91,12 +205,22 @@ export async function POST(request: Request) {
     const image = formData.get("image");
 
     if (!(image instanceof File)) {
-      return jsonError("Send an image file in the image field.", 400);
+      return jsonError(
+        "Send an image file in the image field.",
+        400,
+        "invalid_request",
+      );
     }
 
     if (!image.type.startsWith("image/")) {
-      return jsonError("Only image files are supported.", 400);
+      return jsonError("Only image files are supported.", 400, "invalid_request");
     }
+
+    console.info("[OCR] textDetection request:", {
+      fileType: image.type,
+      fileSize: image.size,
+      isVercel: Boolean(process.env.VERCEL || process.env.VERCEL_ENV),
+    });
 
     const imageBuffer = Buffer.from(await image.arrayBuffer());
     const client = getVisionClient();
@@ -109,7 +233,13 @@ export async function POST(request: Request) {
 
     return NextResponse.json<OcrSuccessResponse>({ text });
   } catch (error) {
-    console.error("[OCR] textDetection failed:", error);
-    return jsonError("OCR processing failed.", 500);
+    const { code, details } = classifyOcrError(error);
+    console.error("[OCR] textDetection failed:", {
+      code,
+      details,
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return jsonError("OCR processing failed.", 500, code, details);
   }
 }


### PR DESCRIPTION
## Summary

Closes #25. Improve the OCR API's Vercel diagnostics so production failures expose a safe, actionable reason instead of only OCR processing failed.

## What changed

- Normalize escaped private key newlines for both GOOGLE_APPLICATION_CREDENTIALS_JSON and individual env-field authentication.
- Accept JSON env values that are accidentally stored as a JSON string.
- Add safe [OCR] Function Log diagnostics for credential source, Vercel runtime, request metadata, and private key format flags without printing secret values.
- Add OCR error codes and sanitized response details so the existing upload UI can show a useful reason.
- Document the private_key newline handling and Vercel Function Log prefix in README.md and docs/HANDOFF.md.

## Validation

- npm run build from frontend/ passed.
- Attempted to inspect Vercel deployment through the Vercel MCP, but runtime logs require the project team ID. This PR adds safe Function Log output so the production cause can be identified from Vercel after deployment.

## Screenshot

N/A