### PR TITLE
docs: clarify daily report handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,3 +136,7 @@ When the user asks for a daily development report, use:
 - `docs/templates/daily-report.md`
 
 Fill the report based on available git history, PR history, issue references, and current conversation context.
+
+Daily development reports should be provided in the chat response unless the user explicitly asks to create or update a repository file.
+
+Do not add daily report files to the repository by default. The template is a reporting format reference, not an instruction to persist reports under `docs/` or any other directory.


### PR DESCRIPTION
## Summary

日次レポートは、ユーザーが明示的にファイル作成を依頼しない限り、チャット内で報告する運用であることをAGENTS.mdに明記しました。

## What changed

- `AGENTS.md` の Reporting Rules に、日次レポートは原則チャット回答として提供することを追記
- `docs/templates/daily-report.md` は保存先指示ではなく、報告フォーマット参照であることを明記
- 日次レポートファイルをリポジトリへデフォルト追加しないルールを追記

## Validation

- Documentation-only change; no build required
- `git status --short --branch` で対象ブランチの状態を確認

## Screenshot

N/A