### PR TITLE
feat(frontend): show bottle recommendation reasons

### DIFF
--- a/frontend/app/bottles/[slug]/page.tsx
+++ b/frontend/app/bottles/[slug]/page.tsx
@@ -58,6 +58,18 @@ export default async function BottleDetailPage({ params }: BottleDetailPageProps
         <p>{bottle.tasteProfile}</p>
       </section>
 
+      {bottle.recommendationReasons.length > 0 ? (
+        <section className="detailCard" aria-labelledby="reason-title">
+          <p className="sectionKicker">Reason</p>
+          <h2 id="reason-title">おすすめ理由</h2>
+          <ul className="reasonList">
+            {bottle.recommendationReasons.map((reason) => (
+              <li key={reason}>{reason}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
       <section className="detailCard" aria-labelledby="for-title">
         <p className="sectionKicker">For You</p>
         <h2 id="for-title">こういう人向け</h2>

--- a/frontend/app/data/distilleries.ts
+++ b/frontend/app/data/distilleries.ts
@@ -3,6 +3,7 @@ export type Bottle = {
   slug: string;
   tasteProfile: string;
   recommendedFor: string;
+  recommendationReasons: string[];
 };
 
 export type Distillery = {
@@ -20,6 +21,7 @@ type DistillerySeed = {
   bottleName?: string;
   tasteProfile?: string;
   recommendedFor?: string;
+  recommendationReasons?: string[];
 };
 
 function normalizeKeyword(value: string) {
@@ -56,6 +58,7 @@ function createDistillery(seed: DistillerySeed): Distillery {
         recommendedFor:
           seed.recommendedFor ??
           "まずは蒸留所の雰囲気を知りたい人や、強いクセよりも飲みやすさを優先したい人向け。",
+        recommendationReasons: seed.recommendationReasons ?? [],
       },
     ],
   };
@@ -69,6 +72,7 @@ const distillerySeeds: DistillerySeed[] = [
     bottleName: "Glenfarclas 12 Year Old",
     tasteProfile: "シェリー樽由来のドライフルーツ、蜂蜜、ナッツ感があり、甘く落ち着いた余韻。",
     recommendedFor: "食後にゆっくり甘みを楽しみたい人や、濃すぎないご褒美感を求める人向け。",
+    recommendationReasons: ["シェリー樽の甘み", "食後にゆっくり飲みたい夜向け"],
   },
   {
     name: "Glenlivet",
@@ -85,6 +89,7 @@ const distillerySeeds: DistillerySeed[] = [
     bottleName: "Bowmore 12 Year Old",
     tasteProfile: "やわらかなスモーク、潮気、ビターなチョコレート感がほどよく重なる味わい。",
     recommendedFor: "強烈すぎないスモーキーさを試したい人や、少し大人っぽい余韻が欲しい人向け。",
+    recommendationReasons: ["スモーキー好きにおすすめ", "アイラ入門にも選びやすい"],
   },
   {
     name: "Highland Park",
@@ -153,6 +158,7 @@ const distillerySeeds: DistillerySeed[] = [
     bottleName: "Talisker 10 Year Old",
     tasteProfile: "潮気、黒胡椒のようなスパイス、焚き火を思わせるスモーク感。",
     recommendedFor: "気分を切り替える一杯が欲しい人や、ハイボールでも個性を感じたい人向け。",
+    recommendationReasons: ["ドライ寄りの味わい", "潮気とスパイス感がある"],
   },
   {
     name: "Glenfiddich",

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -596,6 +596,24 @@ button {
   line-height: 1.75;
 }
 
+.reasonList {
+  display: grid;
+  gap: 8px;
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.reasonList li {
+  padding: 10px 12px;
+  border: 1px solid rgba(213, 162, 77, 0.2);
+  border-radius: 8px;
+  color: var(--gold-soft);
+  background: rgba(213, 162, 77, 0.08);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
 @media (min-width: 720px) {
   .appShell {
     margin-top: 28px;


### PR DESCRIPTION
## Summary

ボトル詳細画面で、次の一本を選ぶ判断材料になる短いおすすめ理由を表示します。

Closes #31

## What changed

- ローカルボトルデータに `recommendationReasons` を追加
- Glenfarclas / Bowmore / Talisker の3本に短い仮理由を追加
- 詳細画面に「おすすめ理由」セクションを条件付き表示
- スマホ幅でも読みやすいよう、短いリスト表示の余白を調整

## Validation

- `npm run build` 成功
- `http://127.0.0.1:3000/bottles/bowmore12yearold` をブラウザ確認
- エラーオーバーレイなし、コンソールエラーなし
- Bowmore詳細でおすすめ理由2件が表示されることを確認

## Screenshot

Codex in-app browserでBowmore詳細画面を確認済み。