### PR TITLE
feat(frontend): add next bottle recommendation card

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -445,10 +445,59 @@ button {
 }
 
 .bottleCandidateCard {
+  display: grid;
+  gap: 10px;
   padding: 12px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 8px;
-  background: rgba(8, 6, 4, 0.34);
+  background:
+    linear-gradient(180deg, rgba(213, 162, 77, 0.11), rgba(8, 6, 4, 0.12)),
+    rgba(8, 6, 4, 0.34);
+}
+
+.nextBottleHeader {
+  display: grid;
+  gap: 7px;
+}
+
+.nextBottleMood {
+  width: fit-content;
+  max-width: 100%;
+  padding: 5px 8px;
+  border: 1px solid rgba(213, 162, 77, 0.24);
+  border-radius: 999px;
+  color: var(--gold-soft);
+  background: rgba(213, 162, 77, 0.09);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.nextBottleLead {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.92rem;
+  font-weight: 700;
+  line-height: 1.55;
+}
+
+.nextBottleFor {
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.nextBottleFor span {
+  display: block;
+  color: var(--gold);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.nextBottleFor p {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.6;
 }
 
 .candidateList {

--- a/frontend/app/scan-uploader.tsx
+++ b/frontend/app/scan-uploader.tsx
@@ -20,6 +20,12 @@ export function ScanUploader() {
   const normalizedText = ocrResult ? normalizeOcrText(ocrResult.text) : "";
   const distilleryCandidate = findDistilleryCandidate(normalizedText);
   const bottleCandidate = distilleryCandidate.bottles[0];
+  const nextBottleRecommendation =
+    bottleCandidate?.recommendationReasons[0] ??
+    "今夜の気分に合わせて試しやすい一本";
+  const nextBottleMood =
+    bottleCandidate?.recommendationReasons[1] ??
+    "静かな夜に、ゆっくり一杯を選びたい時向け";
 
   function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
     const nextFile = event.target.files?.[0] ?? null;
@@ -95,8 +101,16 @@ export function ScanUploader() {
             {bottleCandidate ? (
               <>
                 <div className="bottleCandidateCard">
-                  <p className="candidateLabel">ボトル候補</p>
+                  <div className="nextBottleHeader">
+                    <p className="candidateLabel">次の一本候補</p>
+                    <span className="nextBottleMood">{nextBottleMood}</span>
+                  </div>
                   <h3>{bottleCandidate.name}</h3>
+                  <p className="nextBottleLead">{nextBottleRecommendation}</p>
+                  <div className="nextBottleFor">
+                    <span>こういう人向け</span>
+                    <p>{bottleCandidate.recommendedFor}</p>
+                  </div>
                 </div>
                 <Link className="button buttonLink" href={`/bottles/${bottleCandidate.slug}`}>
                   詳細を見る


### PR DESCRIPTION
## Summary

ボトル候補カードを、単なる候補表示から「次の一本提案」として読めるUIへ寄せました。Issue #33 のMVP方針に合わせて、評価やランキングではなく飲みたい雰囲気と向いている人が伝わる構成にしています。

## What changed

- `frontend/app/scan-uploader.tsx`: ボトル候補カードに一言 recommendation、軽い mood 表現、「こういう人向け」説明を追加
- `frontend/app/globals.css`: 追加した提案要素の余白、タグ、テキスト階層をスマホ向けに調整

## Validation

- `npm run build` succeeded
- Codex in-app browser verification was attempted, but the local browser backend was unavailable in this environment

## Screenshot

N/A: local browser screenshot could not be captured because the Codex in-app browser backend was unavailable.

Closes #33