### PR TITLE
feat(frontend): add bottle taste reaction ui

### DIFF
--- a/frontend/app/bottles/[slug]/page.tsx
+++ b/frontend/app/bottles/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { bottles, findBottleBySlug } from "../../data/distilleries";
+import { TasteReaction } from "./taste-reaction";
 
 type BottleDetailPageProps = {
   params: Promise<{
@@ -75,6 +76,8 @@ export default async function BottleDetailPage({ params }: BottleDetailPageProps
         <h2 id="for-title">こういう人向け</h2>
         <p>{bottle.recommendedFor}</p>
       </section>
+
+      <TasteReaction bottleName={bottle.name} bottleSlug={bottle.slug} />
     </main>
   );
 }

--- a/frontend/app/bottles/[slug]/taste-reaction.tsx
+++ b/frontend/app/bottles/[slug]/taste-reaction.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+type TasteReactionProps = {
+  bottleName: string;
+  bottleSlug: string;
+};
+
+const reactions = [
+  { label: "好き", value: "like" },
+  { label: "そうでもない", value: "neutral" },
+  { label: "苦手", value: "dislike" },
+] as const;
+
+type ReactionValue = (typeof reactions)[number]["value"];
+type Reaction = (typeof reactions)[number];
+
+export function TasteReaction({ bottleName, bottleSlug }: TasteReactionProps) {
+  const [selectedReaction, setSelectedReaction] = useState<ReactionValue | null>(null);
+
+  function handleSelect(reaction: Reaction) {
+    setSelectedReaction(reaction.value);
+    console.log("taste-reaction", {
+      bottle: {
+        name: bottleName,
+        slug: bottleSlug,
+      },
+      reaction: {
+        label: reaction.label,
+        value: reaction.value,
+      },
+    });
+  }
+
+  return (
+    <section className="detailCard tasteReactionCard" aria-labelledby="taste-reaction-title">
+      <p className="sectionKicker">Taste Learning</p>
+      <h2 id="taste-reaction-title">これは好みに近かった？</h2>
+      <div className="tasteReactionButtons" role="group" aria-label={`${bottleName} の好み確認`}>
+        {reactions.map((reaction) => (
+          <button
+            className={
+              selectedReaction === reaction.value
+                ? "tasteReactionButton isSelected"
+                : "tasteReactionButton"
+            }
+            key={reaction.value}
+            type="button"
+            aria-pressed={selectedReaction === reaction.value}
+            onClick={() => handleSelect(reaction)}
+          >
+            {reaction.label}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -614,6 +614,52 @@ button {
   line-height: 1.45;
 }
 
+.tasteReactionCard {
+  background:
+    linear-gradient(180deg, rgba(213, 162, 77, 0.09), rgba(255, 255, 255, 0.015)),
+    rgba(25, 18, 13, 0.8);
+}
+
+.tasteReactionButtons {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 9px;
+  margin-top: 14px;
+}
+
+.tasteReactionButton {
+  min-height: 48px;
+  padding: 0 12px;
+  border: 1px solid rgba(241, 207, 138, 0.22);
+  border-radius: 8px;
+  color: var(--text);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.015)),
+    rgba(12, 9, 7, 0.62);
+  font-size: 0.9rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.tasteReactionButton:active {
+  transform: translateY(1px);
+}
+
+.tasteReactionButton.isSelected {
+  border-color: rgba(241, 207, 138, 0.68);
+  color: #160d07;
+  background: linear-gradient(180deg, #f1cf8a 0%, #c88733 100%);
+  box-shadow:
+    0 10px 22px rgba(169, 96, 34, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.34);
+}
+
+@media (min-width: 390px) {
+  .tasteReactionButtons {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 @media (min-width: 720px) {
   .appShell {
     margin-top: 28px;


### PR DESCRIPTION
## Summary

Bottle detail pages now include a lightweight taste-learning reaction UI so users can quickly tell the recommendation flow whether a bottle felt close to their preference.

Closes #35

## What changed

- Added a local-only `TasteReaction` client component on bottle detail pages.
- Added three non-review reaction choices: 好き / そうでもない / 苦手.
- Logs the selected reaction and target bottle to `console.log` without saving to DB.
- Styled the UI to sit quietly after the recommendation context with mobile-friendly button sizes.

## Validation

- `npm.cmd run build` succeeded.
- `http://localhost:3000/bottles/glenfarclas12yearold` returned HTTP 200 from the local dev server.
- Browser interaction check was not completed because the Codex in-app browser backend was unavailable in this session.

## Screenshot

Not captured: Codex in-app browser backend was unavailable in this session.