### PR TITLE
feat(frontend): persist taste profile reactions

### DIFF
--- a/frontend/app/bottles/[slug]/page.tsx
+++ b/frontend/app/bottles/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { bottles, findBottleBySlug } from "../../data/distilleries";
+import { TasteReaction } from "./taste-reaction";
 
 type BottleDetailPageProps = {
   params: Promise<{
@@ -57,6 +58,8 @@ export default async function BottleDetailPage({ params }: BottleDetailPageProps
         <h2 id="taste-title">味の特徴</h2>
         <p>{bottle.tasteProfile}</p>
       </section>
+
+      <TasteReaction bottleSlug={bottle.slug} bottleName={bottle.name} />
 
       {bottle.recommendationReasons.length > 0 ? (
         <section className="detailCard" aria-labelledby="reason-title">

--- a/frontend/app/bottles/[slug]/taste-reaction.tsx
+++ b/frontend/app/bottles/[slug]/taste-reaction.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type TasteReactionValue = "positive" | "neutral" | "negative";
+
+type StoredTasteReaction = {
+  reaction: TasteReactionValue;
+  bottleSlug: string;
+  bottleName: string;
+  updatedAt: string;
+};
+
+type TasteReactionProps = {
+  bottleSlug: string;
+  bottleName: string;
+};
+
+const reactionOptions: Array<{
+  label: string;
+  value: TasteReactionValue;
+}> = [
+  { label: "好き", value: "positive" },
+  { label: "そうでもない", value: "neutral" },
+  { label: "苦手", value: "negative" },
+];
+
+export function TasteReaction({ bottleSlug, bottleName }: TasteReactionProps) {
+  const [selectedReaction, setSelectedReaction] = useState<TasteReactionValue | null>(null);
+  const [hasSaved, setHasSaved] = useState(false);
+
+  const storageKey = useMemo(
+    () => `whisky-scanner:taste-reaction:${bottleSlug}`,
+    [bottleSlug],
+  );
+
+  useEffect(() => {
+    try {
+      const storedValue = window.localStorage.getItem(storageKey);
+
+      if (!storedValue) {
+        return;
+      }
+
+      const storedReaction = JSON.parse(storedValue) as Partial<StoredTasteReaction>;
+
+      if (
+        storedReaction.bottleSlug === bottleSlug &&
+        isTasteReactionValue(storedReaction.reaction)
+      ) {
+        setSelectedReaction(storedReaction.reaction);
+      }
+    } catch (error) {
+      console.warn("Failed to restore taste reaction", {
+        bottleSlug,
+        error,
+      });
+    }
+  }, [bottleSlug, storageKey]);
+
+  const handleReactionSelect = (reaction: TasteReactionValue) => {
+    const storedReaction: StoredTasteReaction = {
+      reaction,
+      bottleSlug,
+      bottleName,
+      updatedAt: new Date().toISOString(),
+    };
+
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(storedReaction));
+      setSelectedReaction(reaction);
+      setHasSaved(true);
+      console.log("Taste reaction saved", storedReaction);
+    } catch (error) {
+      console.warn("Failed to save taste reaction", {
+        bottleSlug,
+        reaction,
+        error,
+      });
+    }
+  };
+
+  return (
+    <section className="detailCard tasteReactionCard" aria-labelledby="taste-reaction-title">
+      <p className="sectionKicker">Taste Profile</p>
+      <h2 id="taste-reaction-title">この味の記憶</h2>
+      <p className="tasteReactionLead">
+        次の一本を選びやすくするために、今の好みとして軽く覚えておきます。
+      </p>
+      <div className="tasteReactionButtons" role="group" aria-label={`${bottleName}の好み`}>
+        {reactionOptions.map((option) => {
+          const isSelected = selectedReaction === option.value;
+
+          return (
+            <button
+              key={option.value}
+              type="button"
+              className={`tasteReactionButton${isSelected ? " isSelected" : ""}`}
+              aria-pressed={isSelected}
+              onClick={() => handleReactionSelect(option.value)}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+      {hasSaved ? (
+        <p className="tasteReactionFeedback" role="status">
+          好みを覚えました
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function isTasteReactionValue(value: unknown): value is TasteReactionValue {
+  return value === "positive" || value === "neutral" || value === "negative";
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -614,6 +614,62 @@ button {
   line-height: 1.45;
 }
 
+.tasteReactionCard {
+  border-color: rgba(241, 207, 138, 0.16);
+}
+
+.tasteReactionLead {
+  margin-top: 10px;
+}
+
+.tasteReactionButtons {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.tasteReactionButton {
+  min-height: 52px;
+  padding: 0 14px;
+  border: 1px solid rgba(213, 162, 77, 0.24);
+  border-radius: 8px;
+  color: var(--text);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.015)),
+    rgba(20, 15, 11, 0.78);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+}
+
+.tasteReactionButton:active {
+  transform: translateY(1px);
+}
+
+.tasteReactionButton.isSelected {
+  border-color: rgba(241, 207, 138, 0.78);
+  color: #150d07;
+  background:
+    linear-gradient(180deg, #f1cf8a 0%, #c98834 100%);
+  box-shadow:
+    0 12px 28px rgba(169, 96, 34, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.36);
+  font-weight: 800;
+}
+
+.tasteReactionFeedback {
+  margin: 12px 0 0;
+  color: var(--gold-soft);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+@media (min-width: 390px) {
+  .tasteReactionButtons {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 @media (min-width: 720px) {
   .appShell {
     margin-top: 28px;


### PR DESCRIPTION
## Summary

Taste Profile MVPとして、#36で追加済みのボトル詳細画面のTaste Learning UIをベースに、「好き / そうでもない / 苦手」の選択をlocalStorageへ保存し、再訪時に復元できるようにしました。

## What changed

- 既存の `TasteReaction` UI文言を維持
  - `Taste Learning`
  - `これは好みに近かった？`
- ボトルslug単位で `whisky-scanner:taste-reaction:{bottleSlug}` に保存
- 保存値を `positive / neutral / negative` の内部値に整理
- ページ再読み込み後に選択済み状態を復元
- 選択後に控えめな「好みを覚えました」フィードバックを表示

## Validation

- `npm run build`
- Edge DevTools automationで以下を確認
  - Glenfarclas 12 Year Oldで「好き」を選択するとlocalStorageへ `positive` が保存される
  - ページリロード後も「好き」の選択状態が復元される
  - Bowmore 12 Year Oldでは別キーとして未選択から開始し、「苦手」を `negative` として保存できる
  - console.logに対象ボトルと選択内容が出る

## Screenshot

Local browser verification completed at `http://localhost:3000/bottles/glenfarclas12yearold`. Screenshot artifact was not uploaded from the connector environment.

Closes #37