### PR TITLE
feat(frontend): refine recommendation and taste reaction UI

### DIFF
--- a/frontend/app/bottles/[slug]/taste-reaction.tsx
+++ b/frontend/app/bottles/[slug]/taste-reaction.tsx
@@ -9,7 +9,7 @@ type TasteReactionProps = {
 
 const reactions = [
   { label: "好き", value: "positive" },
-  { label: "そうでもない", value: "neutral" },
+  { label: "少し違う", value: "neutral" },
   { label: "苦手", value: "negative" },
 ] as const;
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -130,17 +130,20 @@ button {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 16px;
 }
 
 .todayBadge {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  max-width: 100%;
   padding: 6px 10px;
   border: 1px solid var(--line);
   border-radius: 999px;
   color: var(--gold-soft);
   background: rgba(213, 162, 77, 0.1);
   font-size: 0.78rem;
+  overflow-wrap: anywhere;
 }
 
 .moodGrid {
@@ -159,6 +162,8 @@ button {
     linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.015)),
     rgba(27, 20, 14, 0.88);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
   cursor: pointer;
 }
 
@@ -235,6 +240,7 @@ button {
   font-size: 1.04rem;
   line-height: 1.35;
   letter-spacing: 0;
+  overflow-wrap: anywhere;
 }
 
 .tasteNote {
@@ -258,39 +264,72 @@ button {
 
 .recommendCard {
   display: grid;
-  grid-template-columns: 36px minmax(0, 1fr);
-  gap: 12px;
+  grid-template-columns: 82px minmax(0, 1fr);
+  gap: 14px;
   padding: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.09);
+  border: 1px solid rgba(241, 207, 138, 0.16);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.015)),
+    linear-gradient(135deg, rgba(213, 162, 77, 0.13), rgba(255, 255, 255, 0.02) 42%),
     var(--surface);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.22);
 }
 
-.rank {
+.recommendBottleFrame {
+  position: relative;
   display: grid;
-  place-items: center;
-  width: 36px;
-  height: 36px;
-  border: 1px solid var(--line);
-  border-radius: 50%;
-  color: var(--gold-soft);
-  background: rgba(213, 162, 77, 0.1);
-  font-size: 0.88rem;
-  font-weight: 700;
+  place-items: end center;
+  min-height: 128px;
+  overflow: hidden;
+  border: 1px solid rgba(241, 207, 138, 0.18);
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 50% 24%, rgba(241, 207, 138, 0.3), transparent 34%),
+    linear-gradient(180deg, rgba(36, 25, 16, 0.9), rgba(10, 8, 6, 0.92));
+}
+
+.recommendBottleCap {
+  position: absolute;
+  top: 17px;
+  width: 22px;
+  height: 30px;
+  border-radius: 9px 9px 3px 3px;
+  background: linear-gradient(180deg, #f1cf8a, #70421c);
+  box-shadow: 0 0 18px rgba(241, 207, 138, 0.16);
+}
+
+.recommendBottleShape {
+  width: 42px;
+  height: 86px;
+  margin-bottom: 14px;
+  border: 1px solid rgba(255, 226, 162, 0.25);
+  border-radius: 18px 18px 8px 8px;
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.24), transparent 22%),
+    linear-gradient(180deg, rgba(213, 162, 77, 0.72), rgba(92, 48, 18, 0.9));
+  box-shadow:
+    inset 0 0 18px rgba(255, 226, 162, 0.16),
+    0 12px 24px rgba(0, 0, 0, 0.28);
 }
 
 .recommendTop {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
+}
+
+.nextPickLabel {
+  color: var(--gold);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
 }
 
 .matchScore {
+  flex: 0 0 auto;
   color: var(--gold-soft);
-  font-size: 0.78rem;
+  font-size: 0.72rem;
   font-weight: 700;
 }
 
@@ -298,6 +337,7 @@ button {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+  margin-top: 10px;
 }
 
 .tagList span {
@@ -315,6 +355,14 @@ button {
   color: var(--muted);
   font-size: 0.84rem;
   line-height: 1.55;
+}
+
+.recommendCard .nextMoment {
+  margin-top: 8px;
+  color: var(--gold-soft);
+  font-size: 0.86rem;
+  font-weight: 800;
+  line-height: 1.45;
 }
 
 .sectionLead {
@@ -677,17 +725,36 @@ button {
 }
 
 .tasteReactionButton {
-  min-height: 48px;
-  padding: 0 12px;
-  border: 1px solid rgba(241, 207, 138, 0.22);
+  position: relative;
+  min-height: 52px;
+  padding: 0 14px 0 36px;
+  border: 1px solid rgba(241, 207, 138, 0.32);
   border-radius: 8px;
   color: var(--text);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.015)),
-    rgba(12, 9, 7, 0.62);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.085), rgba(255, 255, 255, 0.018)),
+    rgba(12, 9, 7, 0.78);
+  box-shadow:
+    0 8px 18px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.09);
   font-size: 0.9rem;
   font-weight: 750;
+  line-height: 1.25;
+  text-align: left;
   cursor: pointer;
+}
+
+.tasteReactionButton::before {
+  position: absolute;
+  left: 13px;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  border: 1px solid rgba(241, 207, 138, 0.58);
+  border-radius: 50%;
+  background: rgba(241, 207, 138, 0.08);
+  content: "";
+  transform: translateY(-50%);
 }
 
 .tasteReactionButton:active {
@@ -701,6 +768,13 @@ button {
   box-shadow:
     0 10px 22px rgba(169, 96, 34, 0.2),
     inset 0 1px 0 rgba(255, 255, 255, 0.34);
+}
+
+.tasteReactionButton.isSelected::before {
+  border-color: rgba(22, 13, 7, 0.48);
+  background:
+    radial-gradient(circle, #160d07 0 38%, transparent 42%),
+    rgba(255, 255, 255, 0.22);
 }
 
 .tasteReactionFeedback {

--- a/frontend/app/home-experience.tsx
+++ b/frontend/app/home-experience.tsx
@@ -14,6 +14,7 @@ type Recommendation = {
   tags: string[];
   reason: string;
   match: string;
+  nextMoment: string;
 };
 
 const moods = [
@@ -40,18 +41,21 @@ const recommendationsByMood: Record<Mood, Recommendation[]> = {
       tags: ["バニラ", "柑橘", "やさしい"],
       reason: "軽やかな甘さと柑橘感で、力を抜きたい夜に寄り添いやすいから。",
       match: "91%",
+      nextMoment: "肩の力を抜きたい夜に",
     },
     {
       name: "The Balvenie DoubleWood 12",
       tags: ["蜂蜜", "樽香", "なめらか"],
       reason: "最近好きだった甘い余韻に近く、安心して戻れる味わいだから。",
       match: "89%",
+      nextMoment: "食後にゆっくり戻りたい時に",
     },
     {
       name: "Arran 10",
       tags: ["果実", "モルト", "穏やか"],
       reason: "派手すぎない果実味で、ゆっくり一杯に向いているから。",
       match: "86%",
+      nextMoment: "静かに一杯だけ飲みたい時に",
     },
   ],
   "スモーク欲しい": [
@@ -60,18 +64,21 @@ const recommendationsByMood: Record<Mood, Recommendation[]> = {
       tags: ["スモーク", "潮気", "チョコ"],
       reason: "強すぎない煙と甘さがあり、スモーク入門としても選びやすいから。",
       match: "93%",
+      nextMoment: "煙たさを少し足したい夜に",
     },
     {
       name: "Talisker 10",
       tags: ["黒胡椒", "潮気", "焚き火"],
       reason: "ピリッとした余韻があり、気分を切り替えたい夜に合うから。",
       match: "88%",
+      nextMoment: "気分を切り替えたい一杯に",
     },
     {
       name: "Caol Ila 12",
       tags: ["ピート", "レモン", "クリーン"],
       reason: "煙たさはしっかりありつつ、重すぎず飲み進めやすいから。",
       match: "85%",
+      nextMoment: "軽やかなスモークを試したい時に",
     },
   ],
   "ご褒美": [
@@ -80,18 +87,21 @@ const recommendationsByMood: Record<Mood, Recommendation[]> = {
       tags: ["シェリー樽", "ドライフルーツ", "なめらか"],
       reason: "好きだった蜂蜜感を残しながら、果実の厚みを少し足せるから。",
       match: "92%",
+      nextMoment: "今夜のご褒美に",
     },
     {
       name: "Aberlour 12 Double Cask",
       tags: ["濃厚", "蜂蜜", "ご褒美"],
       reason: "やさしい甘さから一歩進んで、満足感のある夜に合うから。",
       match: "88%",
+      nextMoment: "甘く濃い満足感がほしい時に",
     },
     {
       name: "Bunnahabhain 12",
       tags: ["穏やか", "ナッツ", "潮気"],
       reason: "まろやかな甘さに控えめな海のニュアンスが加わり、新しい発見があるから。",
       match: "84%",
+      nextMoment: "少しだけ新しい味に進みたい時に",
     },
   ],
   "食事と合わせたい": [
@@ -100,18 +110,21 @@ const recommendationsByMood: Record<Mood, Recommendation[]> = {
       tags: ["ハニー", "軽快", "食中"],
       reason: "甘さが穏やかで、炭酸割りでも食事の邪魔をしにくいから。",
       match: "90%",
+      nextMoment: "食事を邪魔しないハイボールに",
     },
     {
       name: "Monkey Shoulder",
       tags: ["モルト", "バニラ", "万能"],
       reason: "ハイボールでもロックでも合わせやすく、料理を選びにくいから。",
       match: "87%",
+      nextMoment: "飲み方を決めずに開けたい時に",
     },
     {
       name: "Chivas Regal Mizunara 12",
       tags: ["やわらか", "樽香", "和食"],
       reason: "穏やかな樽の香りで、和食や軽めのつまみに寄せやすいから。",
       match: "84%",
+      nextMoment: "軽めのつまみと合わせたい時に",
     },
   ],
   "冒険したい": [
@@ -120,18 +133,21 @@ const recommendationsByMood: Record<Mood, Recommendation[]> = {
       tags: ["スパイス", "濃厚", "新世界"],
       reason: "いつもの甘い樽感から少し離れて、香味の広がりを試せるから。",
       match: "89%",
+      nextMoment: "いつもと違う発見がほしい夜に",
     },
     {
       name: "Kavalan Concertmaster",
       tags: ["トロピカル", "ワイン樽", "華やか"],
       reason: "果実感がはっきりしていて、次の発見として分かりやすいから。",
       match: "86%",
+      nextMoment: "華やかな果実感を試したい時に",
     },
     {
       name: "Nikka From The Barrel",
       tags: ["力強い", "スパイス", "濃密"],
       reason: "アルコール感と厚みがあり、少量でも満足する冒険感があるから。",
       match: "83%",
+      nextMoment: "少量でしっかり楽しみたい時に",
     },
   ],
   "ハイボールしたい": [
@@ -140,18 +156,21 @@ const recommendationsByMood: Record<Mood, Recommendation[]> = {
       tags: ["爽快", "青りんご", "ハイボール"],
       reason: "炭酸で香りが立ちやすく、軽快に今夜の一杯を始められるから。",
       match: "92%",
+      nextMoment: "最初の一杯を爽快にしたい時に",
     },
     {
       name: "The Glenlivet 12",
       tags: ["洋梨", "軽やか", "すっきり"],
       reason: "果実の甘さが炭酸で伸びて、食事前にも飲みやすいから。",
       match: "88%",
+      nextMoment: "食事前に軽く飲みたい時に",
     },
     {
       name: "Johnnie Walker Black Label",
       tags: ["スモーク", "バニラ", "定番"],
       reason: "少し煙のある余韻が残り、ハイボールでも物足りなさが出にくいから。",
       match: "85%",
+      nextMoment: "定番感と飲みごたえを両方ほしい時に",
     },
   ],
 };
@@ -230,18 +249,23 @@ export function HomeExperience({ health }: HomeExperienceProps) {
         <div className="recommendList">
           {recommendations.map((bottle, index) => (
             <article className="recommendCard" key={bottle.name}>
-              <div className="rank">{index + 1}</div>
+              <div className="recommendBottleFrame" aria-hidden="true">
+                <span className="recommendBottleCap" />
+                <span className="recommendBottleShape" />
+              </div>
               <div className="recommendBody">
                 <div className="recommendTop">
-                  <div className="tagList">
-                    {bottle.tags.map((tag) => (
-                      <span key={tag}>{tag}</span>
-                    ))}
-                  </div>
-                  <span className="matchScore">{bottle.match}</span>
+                  <span className="nextPickLabel">次の一本候補 {index + 1}</span>
+                  <span className="matchScore">相性 {bottle.match}</span>
                 </div>
                 <h3>{bottle.name}</h3>
+                <p className="nextMoment">{bottle.nextMoment}</p>
                 <p>{bottle.reason}</p>
+                <div className="tagList" aria-label="味の手がかり">
+                  {bottle.tags.map((tag) => (
+                    <span key={tag}>{tag}</span>
+                  ))}
+                </div>
               </div>
             </article>
           ))}


### PR DESCRIPTION
## Summary

Issue #40 のスマホ実機確認フィードバックを踏まえ、recommendationカードを「次の一本提案」として読みやすくし、Taste ProfileリアクションUIの押せる感と文言を調整しました。

## What changed

- `frontend/app/home-experience.tsx`: recommendationカードに「次の一本候補」「今夜の飲みどころ」を追加し、タグや相性スコアを補足情報に整理
- `frontend/app/globals.css`: recommendationカードにボトルプレースホルダー枠を追加し、モバイルでの折り返し・押しやすさ・選択状態を調整
- `frontend/app/bottles/[slug]/taste-reaction.tsx`: 「そうでもない」を「少し違う」に変更して、スマホ幅で読みやすい文言に調整

## Validation

- `npm.cmd run build` 成功
- `npm.cmd run dev` で `http://localhost:3000` が HTTP 200 を返すことを確認
- Headless Edge でローカル表示確認を試行。環境都合で最終スクリーンショット添付は未実施

## Screenshot

N/A（ローカルのヘッドレスブラウザ検証は実施しましたが、PR添付用スクリーンショットは未添付です）

Closes #40