### PR TITLE
feat(frontend): redesign taste reaction direction input

### DIFF
--- a/frontend/app/bottles/[slug]/page.tsx
+++ b/frontend/app/bottles/[slug]/page.tsx
@@ -71,13 +71,14 @@ export default async function BottleDetailPage({ params }: BottleDetailPageProps
         </section>
       ) : null}
 
+      <TasteReaction bottleName={bottle.name} bottleSlug={bottle.slug} />
+
       <section className="detailCard" aria-labelledby="for-title">
         <p className="sectionKicker">For You</p>
         <h2 id="for-title">こういう人向け</h2>
         <p>{bottle.recommendedFor}</p>
       </section>
 
-      <TasteReaction bottleName={bottle.name} bottleSlug={bottle.slug} />
     </main>
   );
 }

--- a/frontend/app/bottles/[slug]/taste-reaction.tsx
+++ b/frontend/app/bottles/[slug]/taste-reaction.tsx
@@ -8,13 +8,26 @@ type TasteReactionProps = {
 };
 
 const reactions = [
-  { label: "好き", value: "positive" },
-  { label: "少し違う", value: "neutral" },
-  { label: "苦手", value: "negative" },
+  {
+    label: "また飲みたい",
+    value: "want_again",
+    feedback: "次のおすすめに覚えておきます。",
+  },
+  {
+    label: "たまになら",
+    value: "occasionally",
+    feedback: "気分に合わせて参考にします。",
+  },
+  {
+    label: "別のタイプ",
+    value: "different_type",
+    feedback: "次は別のタイプも探してみます。",
+  },
 ] as const;
 
 type ReactionValue = (typeof reactions)[number]["value"];
 type Reaction = (typeof reactions)[number];
+type LegacyReactionValue = "positive" | "neutral" | "negative";
 
 type StoredTasteReaction = {
   reaction: ReactionValue;
@@ -41,12 +54,10 @@ export function TasteReaction({ bottleName, bottleSlug }: TasteReactionProps) {
       }
 
       const storedReaction = JSON.parse(storedValue) as Partial<StoredTasteReaction>;
+      const reactionValue = normalizeReactionValue(storedReaction.reaction);
 
-      if (
-        storedReaction.bottleSlug === bottleSlug &&
-        isReactionValue(storedReaction.reaction)
-      ) {
-        setSelectedReaction(storedReaction.reaction);
+      if (storedReaction.bottleSlug === bottleSlug && reactionValue) {
+        setSelectedReaction(reactionValue);
       }
     } catch (error) {
       console.warn("Failed to restore taste reaction", {
@@ -87,11 +98,19 @@ export function TasteReaction({ bottleName, bottleSlug }: TasteReactionProps) {
     }
   }
 
+  const selectedFeedback = reactions.find(
+    (reaction) => reaction.value === selectedReaction,
+  )?.feedback;
+
   return (
     <section className="detailCard tasteReactionCard" aria-labelledby="taste-reaction-title">
-      <p className="sectionKicker">Taste Learning</p>
-      <h2 id="taste-reaction-title">これは好みに近かった？</h2>
-      <div className="tasteReactionButtons" role="group" aria-label={`${bottleName} の好み確認`}>
+      <p className="sectionKicker">Next Pick</p>
+      <h2 id="taste-reaction-title">この一本、次も選びたい？</h2>
+      <div
+        className="tasteReactionButtons"
+        role="group"
+        aria-label={`${bottleName} を次のおすすめに反映する方向性`}
+      >
         {reactions.map((reaction) => (
           <button
             className={
@@ -108,15 +127,38 @@ export function TasteReaction({ bottleName, bottleSlug }: TasteReactionProps) {
           </button>
         ))}
       </div>
-      {hasSaved ? (
+      <p className="tasteReactionHelper">次のおすすめに少しずつ反映します</p>
+      {hasSaved && selectedFeedback ? (
         <p className="tasteReactionFeedback" role="status">
-          好みを覚えました
+          {selectedFeedback}
         </p>
       ) : null}
     </section>
   );
 }
 
+function normalizeReactionValue(value: unknown): ReactionValue | null {
+  if (isReactionValue(value)) {
+    return value;
+  }
+
+  const legacyValues: Record<LegacyReactionValue, ReactionValue> = {
+    positive: "want_again",
+    neutral: "occasionally",
+    negative: "different_type",
+  };
+
+  if (isLegacyReactionValue(value)) {
+    return legacyValues[value];
+  }
+
+  return null;
+}
+
 function isReactionValue(value: unknown): value is ReactionValue {
   return reactions.some((reaction) => reaction.value === value);
+}
+
+function isLegacyReactionValue(value: unknown): value is LegacyReactionValue {
+  return value === "positive" || value === "neutral" || value === "negative";
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -712,22 +712,32 @@ button {
 }
 
 .tasteReactionCard {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+  border-color: rgba(241, 207, 138, 0.22);
   background:
-    linear-gradient(180deg, rgba(213, 162, 77, 0.09), rgba(255, 255, 255, 0.015)),
+    linear-gradient(180deg, rgba(213, 162, 77, 0.12), rgba(255, 255, 255, 0.018)),
     rgba(25, 18, 13, 0.8);
+}
+
+.tasteReactionCard h2 {
+  margin-top: 0;
+  max-width: 15rem;
+  font-size: 1.16rem;
+  line-height: 1.45;
 }
 
 .tasteReactionButtons {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 9px;
-  margin-top: 14px;
+  gap: 10px;
+  margin-top: 2px;
 }
 
 .tasteReactionButton {
-  position: relative;
-  min-height: 52px;
-  padding: 0 14px 0 36px;
+  min-height: 54px;
+  padding: 0 16px;
   border: 1px solid rgba(241, 207, 138, 0.32);
   border-radius: 8px;
   color: var(--text);
@@ -739,22 +749,9 @@ button {
     inset 0 1px 0 rgba(255, 255, 255, 0.09);
   font-size: 0.9rem;
   font-weight: 750;
-  line-height: 1.25;
-  text-align: left;
+  line-height: 1.35;
+  text-align: center;
   cursor: pointer;
-}
-
-.tasteReactionButton::before {
-  position: absolute;
-  left: 13px;
-  top: 50%;
-  width: 12px;
-  height: 12px;
-  border: 1px solid rgba(241, 207, 138, 0.58);
-  border-radius: 50%;
-  background: rgba(241, 207, 138, 0.08);
-  content: "";
-  transform: translateY(-50%);
 }
 
 .tasteReactionButton:active {
@@ -770,23 +767,29 @@ button {
     inset 0 1px 0 rgba(255, 255, 255, 0.34);
 }
 
-.tasteReactionButton.isSelected::before {
-  border-color: rgba(22, 13, 7, 0.48);
-  background:
-    radial-gradient(circle, #160d07 0 38%, transparent 42%),
-    rgba(255, 255, 255, 0.22);
+.tasteReactionHelper {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.6;
 }
 
 .tasteReactionFeedback {
-  margin: 12px 0 0;
+  margin: 0;
   color: var(--gold-soft);
   font-size: 0.82rem;
   font-weight: 700;
+  line-height: 1.55;
 }
 
-@media (min-width: 390px) {
+@media (min-width: 420px) {
   .tasteReactionButtons {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .tasteReactionButton {
+    min-height: 58px;
+    padding: 0 10px;
   }
 }
 


### PR DESCRIPTION
## Summary

Taste ProfileリアクションUIをレビュー/評価ではなく、次回のおすすめを育てる方向性入力として見えるように再設計しました。

## What changed

- ボトル詳細のリアクション文言を「この一本、次も選びたい？」と「また飲みたい / たまになら / 別のタイプ」に変更
- 保存後フィードバックを選択肢ごとの次のおすすめ文脈に変更
- localStorageの保存キーは維持し、保存値を `want_again / occasionally / different_type` に変更
- 旧保存値 `positive / neutral / negative` は読み込み時に簡易変換
- リアクションUIをおすすめ理由の直後に移動し、ボタン幅・余白・行間をスマホ向けに調整

## Validation

- `npm.cmd run build` 成功
- dev server起動中に `http://127.0.0.1:3000/bottles/glenfarclas12yearold` へHTTP 200応答を確認
- HTMLレスポンス内に「この一本、次も選びたい？」「また飲みたい」が含まれることを確認
- in-app browserでのスクリーンショット取得は `net::ERR_BLOCKED_BY_CLIENT` により未完了

## Screenshot

スクリーンショット取得は未完了です。in-app browserで localhost / 127.0.0.1 が `net::ERR_BLOCKED_BY_CLIENT` になったため、今回は build とHTTP応答確認まで実施しました.

Closes #44