### PR TITLE
feat(frontend): add primary bottle recommendations

### DIFF
--- a/frontend/app/bottles/[slug]/page.tsx
+++ b/frontend/app/bottles/[slug]/page.tsx
@@ -65,6 +65,14 @@ export default async function BottleDetailPage({ params }: BottleDetailPageProps
         <p>{bottle.tasteProfile}</p>
       </section>
 
+      {bottle.recommendation ? (
+        <section className="detailCard" aria-labelledby="recommendation-title">
+          <p className="sectionKicker">Next Bottle</p>
+          <h2 id="recommendation-title">次の一本として見るなら</h2>
+          <p>{bottle.recommendation.detailRecommendation}</p>
+        </section>
+      ) : null}
+
       {bottle.recommendationReasons.length > 0 ? (
         <section className="detailCard" aria-labelledby="reason-title">
           <p className="sectionKicker">Reason</p>

--- a/frontend/app/data/bottle-recommendations.ts
+++ b/frontend/app/data/bottle-recommendations.ts
@@ -1,0 +1,115 @@
+export type BottleRecommendation = {
+  bottleId: string;
+  cardRecommendation: string;
+  detailRecommendation: string;
+  directionTags: string[];
+  moodTags: string[];
+  sceneTags: string[];
+};
+
+const bottleRecommendations: Record<string, BottleRecommendation> = {
+  lagavulin16yearold: {
+    bottleId: "lagavulin16yearold",
+    cardRecommendation:
+      "深いスモークや余韻をゆっくり楽しみたい夜に。強い味わいへ進みたいときの候補です。",
+    detailRecommendation:
+      "しっかりしたピートや潮気のある味が好きなら、この方向は次の一本の手がかりになります。食後に少し時間をかけて、濃い余韻を楽しみたい日に向いています。",
+    directionTags: ["smoky", "coastal", "rich"],
+    moodTags: ["quiet-night", "after-dinner", "slow-drink"],
+    sceneTags: ["solo-drink", "deep-smoke", "nightcap"],
+  },
+  ardbeg10yearold: {
+    bottleId: "ardbeg10yearold",
+    cardRecommendation:
+      "はっきりしたスモークを試したいならこの方向。力強い一本に進みたい日に合います。",
+    detailRecommendation:
+      "スモーキーさをもっと前に出したいときに選びやすい候補です。甘さよりもピートやドライな余韻を楽しみたい夜の手がかりになります。",
+    directionTags: ["smoky", "peaty", "dry"],
+    moodTags: ["adventurous", "quiet-night", "slow-drink"],
+    sceneTags: ["bold-smoke", "solo-drink", "after-dinner"],
+  },
+  bowmore12yearold: {
+    bottleId: "bowmore12yearold",
+    cardRecommendation:
+      "やわらかなスモークから入りたいときに。アイラらしさを穏やかに試せる候補です。",
+    detailRecommendation:
+      "スモーキーな方向に興味はあるけれど、強すぎる味は少し不安なときに見やすい一本です。潮気や甘さもあり、最初のアイラ候補としても使いやすい手がかりになります。",
+    directionTags: ["smoky", "coastal", "gentle"],
+    moodTags: ["relaxing", "rainy-day", "slow-drink"],
+    sceneTags: ["first-islay", "home-drink", "bar-time"],
+  },
+  talisker10yearold: {
+    bottleId: "talisker10yearold",
+    cardRecommendation:
+      "潮気やスパイス感がほしい日に。甘さだけではない一本へ進みたいときの候補です。",
+    detailRecommendation:
+      "果実の甘さよりも、潮気や黒胡椒のような刺激を少し足したいときに向いています。ハイボールでも個性が残りやすく、気分を切り替えたい日の手がかりになります。",
+    directionTags: ["coastal", "spicy", "smoky"],
+    moodTags: ["rainy-day", "refreshing", "slow-drink"],
+    sceneTags: ["highball", "solo-drink", "bar-time"],
+  },
+  springbank10yearold: {
+    bottleId: "springbank10yearold",
+    cardRecommendation:
+      "素朴さや奥行きのある味を探したいときに。少し通好みの方向へ進む候補です。",
+    detailRecommendation:
+      "きれいに整いすぎた味よりも、香ばしさやオイリーさのある表情を楽しみたい日に合います。ゆっくり飲みながら変化を見る一本として使いやすい手がかりです。",
+    directionTags: ["oily", "coastal", "complex"],
+    moodTags: ["slow-drink", "quiet-night", "curious"],
+    sceneTags: ["solo-drink", "deep-dive", "after-dinner"],
+  },
+  arran10yearold: {
+    bottleId: "arran10yearold",
+    cardRecommendation:
+      "明るい果実感と軽やかさを探す日に。重すぎない一本へ進みたいときの候補です。",
+    detailRecommendation:
+      "華やかな果実感やモルトの甘さを、気軽に楽しみたいときに見やすい一本です。強いスモークよりも、明るく飲み進めやすい方向を探す手がかりになります。",
+    directionTags: ["fruity", "light", "malty"],
+    moodTags: ["relaxing", "fresh-start", "easy-night"],
+    sceneTags: ["home-drink", "first-single-malt", "casual"],
+  },
+  glenfarclas12yearold: {
+    bottleId: "glenfarclas12yearold",
+    cardRecommendation:
+      "シェリー樽の甘みをゆっくり楽しみたい日に。食後の一杯として見やすい候補です。",
+    detailRecommendation:
+      "ドライフルーツやナッツのような甘さが好きなら、この方向は次の一本の手がかりになります。強いスモークよりも、落ち着いた甘みを食後に楽しみたい日に向いています。",
+    directionTags: ["sherry", "sweet", "nutty"],
+    moodTags: ["after-dinner", "quiet-night", "slow-drink"],
+    sceneTags: ["dessert-pairing", "home-drink", "nightcap"],
+  },
+  glenfiddich12yearold: {
+    bottleId: "glenfiddich12yearold",
+    cardRecommendation:
+      "青りんごのような軽さを探す日に。すっきりしたシングルモルト候補です。",
+    detailRecommendation:
+      "重い樽感よりも、軽やかな果実感や飲みやすさを優先したいときに見やすい一本です。最初のシングルモルトや、気軽に開けたい夜の手がかりになります。",
+    directionTags: ["fruity", "light", "fresh"],
+    moodTags: ["relaxing", "fresh-start", "easy-night"],
+    sceneTags: ["first-single-malt", "home-drink", "casual"],
+  },
+  themacallan12yearold: {
+    bottleId: "themacallan12yearold",
+    cardRecommendation:
+      "上品な甘みや樽の深みを探す日に。少し特別感のある候補です。",
+    detailRecommendation:
+      "シェリー樽由来の甘みや落ち着いた厚みを楽しみたいときに見やすい一本です。にぎやかに飲むより、食後にゆっくり味を確かめたい日の手がかりになります。",
+    directionTags: ["sherry", "elegant", "rich"],
+    moodTags: ["after-dinner", "celebratory", "slow-drink"],
+    sceneTags: ["special-night", "gift-idea", "nightcap"],
+  },
+  benromach10yearold: {
+    bottleId: "benromach10yearold",
+    cardRecommendation:
+      "甘さに少しスモークを足したいときに。クラシックな方向へ進む候補です。",
+    detailRecommendation:
+      "シェリーの甘みだけでは少し物足りない日に、やさしいピート感を足す手がかりになります。派手すぎず、食後や静かな夜にじっくり試しやすい一本です。",
+    directionTags: ["sherry", "smoky", "classic"],
+    moodTags: ["quiet-night", "after-dinner", "slow-drink"],
+    sceneTags: ["home-drink", "classic-malt", "solo-drink"],
+  },
+};
+
+export function getBottleRecommendation(bottleId: string) {
+  return bottleRecommendations[bottleId];
+}

--- a/frontend/app/data/distilleries.ts
+++ b/frontend/app/data/distilleries.ts
@@ -1,9 +1,15 @@
+import {
+  getBottleRecommendation,
+  type BottleRecommendation,
+} from "./bottle-recommendations";
+
 export type Bottle = {
   name: string;
   slug: string;
   tasteProfile: string;
   recommendedFor: string;
   recommendationReasons: string[];
+  recommendation?: BottleRecommendation;
 };
 
 export type Distillery = {
@@ -42,6 +48,7 @@ function createDistillery(seed: DistillerySeed): Distillery {
     new Set([...englishKeywords, ...(seed.keywords ?? [])].map(normalizeKeyword)),
   );
   const bottleName = seed.bottleName ?? `${seed.name} Single Malt`;
+  const bottleSlug = createSlug(bottleName);
 
   return {
     slug: createSlug(seed.name),
@@ -51,7 +58,7 @@ function createDistillery(seed: DistillerySeed): Distillery {
     bottles: [
       {
         name: bottleName,
-        slug: createSlug(bottleName),
+        slug: bottleSlug,
         tasteProfile:
           seed.tasteProfile ??
           "モルトの甘さ、穏やかな樽香、軽い果実感を中心にした飲みやすい味わい。",
@@ -59,6 +66,7 @@ function createDistillery(seed: DistillerySeed): Distillery {
           seed.recommendedFor ??
           "まずは蒸留所の雰囲気を知りたい人や、強いクセよりも飲みやすさを優先したい人向け。",
         recommendationReasons: seed.recommendationReasons ?? [],
+        recommendation: getBottleRecommendation(bottleSlug),
       },
     ],
   };
@@ -230,7 +238,12 @@ const distillerySeeds: DistillerySeed[] = [
   { name: "Craigellachie", region: "Speyside", keywords: ["クライゲラキ"] },
   { name: "Dallas Dhu", region: "Speyside", keywords: ["dallasdhu", "ダラスデュー"] },
   { name: "Glenlossie", region: "Speyside", keywords: ["グレンロッシー"] },
-  { name: "Benromach", region: "Speyside", keywords: ["ベンロマック"] },
+  {
+    name: "Benromach",
+    region: "Speyside",
+    keywords: ["ベンロマック"],
+    bottleName: "Benromach 10 Year Old",
+  },
   { name: "Balmenach", region: "Speyside", keywords: ["バルメナック"] },
   { name: "St Magdalene", region: "Lowland", keywords: ["saint magdalene", "セントマグダレン"] },
   { name: "Bladnoch", region: "Lowland", keywords: ["ブラドノック"] },

--- a/frontend/app/home-experience.tsx
+++ b/frontend/app/home-experience.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { getBottleRecommendation } from "./data/bottle-recommendations";
 import { ScanUploader } from "./scan-uploader";
 
 type HealthStatus = {
@@ -11,6 +12,7 @@ type HealthStatus = {
 
 type Recommendation = {
   name: string;
+  bottleId?: string;
   tags: string[];
   reason: string;
   match: string;
@@ -52,6 +54,7 @@ const recommendationsByMood: Record<Mood, Recommendation[]> = {
     },
     {
       name: "Arran 10",
+      bottleId: "arran10yearold",
       tags: ["果実", "モルト", "穏やか"],
       reason: "派手すぎない果実味で、ゆっくり一杯に向いているから。",
       match: "86%",
@@ -61,6 +64,7 @@ const recommendationsByMood: Record<Mood, Recommendation[]> = {
   "スモーク欲しい": [
     {
       name: "Bowmore 12",
+      bottleId: "bowmore12yearold",
       tags: ["スモーク", "潮気", "チョコ"],
       reason: "強すぎない煙と甘さがあり、スモーク入門としても選びやすいから。",
       match: "93%",
@@ -68,6 +72,7 @@ const recommendationsByMood: Record<Mood, Recommendation[]> = {
     },
     {
       name: "Talisker 10",
+      bottleId: "talisker10yearold",
       tags: ["黒胡椒", "潮気", "焚き火"],
       reason: "ピリッとした余韻があり、気分を切り替えたい夜に合うから。",
       match: "88%",
@@ -247,28 +252,34 @@ export function HomeExperience({ health }: HomeExperienceProps) {
         </div>
 
         <div className="recommendList">
-          {recommendations.map((bottle, index) => (
-            <article className="recommendCard" key={bottle.name}>
-              <div className="recommendBottleFrame" aria-hidden="true">
-                <span className="recommendBottleCap" />
-                <span className="recommendBottleShape" />
-              </div>
-              <div className="recommendBody">
-                <div className="recommendTop">
-                  <span className="nextPickLabel">次の一本候補 {index + 1}</span>
-                  <span className="matchScore">相性 {bottle.match}</span>
+          {recommendations.map((bottle, index) => {
+            const recommendationCopy = bottle.bottleId
+              ? getBottleRecommendation(bottle.bottleId)?.cardRecommendation
+              : undefined;
+
+            return (
+              <article className="recommendCard" key={bottle.name}>
+                <div className="recommendBottleFrame" aria-hidden="true">
+                  <span className="recommendBottleCap" />
+                  <span className="recommendBottleShape" />
                 </div>
-                <h3>{bottle.name}</h3>
-                <p className="nextMoment">{bottle.nextMoment}</p>
-                <p>{bottle.reason}</p>
-                <div className="tagList" aria-label="味の手がかり">
-                  {bottle.tags.map((tag) => (
-                    <span key={tag}>{tag}</span>
-                  ))}
+                <div className="recommendBody">
+                  <div className="recommendTop">
+                    <span className="nextPickLabel">次の一本候補 {index + 1}</span>
+                    <span className="matchScore">相性 {bottle.match}</span>
+                  </div>
+                  <h3>{bottle.name}</h3>
+                  <p className="nextMoment">{bottle.nextMoment}</p>
+                  <p>{recommendationCopy ?? bottle.reason}</p>
+                  <div className="tagList" aria-label="味の手がかり">
+                    {bottle.tags.map((tag) => (
+                      <span key={tag}>{tag}</span>
+                    ))}
+                  </div>
                 </div>
-              </div>
-            </article>
-          ))}
+              </article>
+            );
+          })}
         </div>
       </section>
 

--- a/frontend/app/scan-uploader.tsx
+++ b/frontend/app/scan-uploader.tsx
@@ -21,6 +21,7 @@ export function ScanUploader() {
   const distilleryCandidate = findDistilleryCandidate(normalizedText);
   const bottleCandidate = distilleryCandidate.bottles[0];
   const nextBottleRecommendation =
+    bottleCandidate?.recommendation?.cardRecommendation ??
     bottleCandidate?.recommendationReasons[0] ??
     "今夜の気分に合わせて試しやすい一本";
   const nextBottleMood =


### PR DESCRIPTION
## Summary

主要10本の recommendation 文をローカルデータへ追加し、ボトル候補カードとボトル詳細画面で表示されるようにしました。

## What changed

- `frontend/app/data/bottle-recommendations.ts` を追加
- `BottleRecommendation` として `cardRecommendation` / `detailRecommendation` / `directionTags` / `moodTags` / `sceneTags` を定義
- 対象10本に recommendation を紐づけ
  - Lagavulin 16
  - Ardbeg 10
  - Bowmore 12
  - Talisker 10
  - Springbank 10
  - Arran 10
  - Glenfarclas 12
  - Glenfiddich 12
  - The Macallan 12
  - Benromach 10
- ボトル詳細画面に `detailRecommendation` を表示
- ラベル検索後のボトル候補カードで `cardRecommendation` を優先表示
- ホームの既存おすすめカードのうち、対象ボトルは `cardRecommendation` を優先表示
- `Benromach` は対象指定に合わせて `Benromach 10 Year Old` として扱うようにしました

## Validation

- `npm.cmd run build` 成功
- 対象10本すべてに recommendation が紐づいていることをスクリプトで確認
- dev server起動中に `http://127.0.0.1:3000/bottles/lagavulin16yearold` がHTTP 200を返すことを確認
- HTMLレスポンス内に `次の一本として見るなら` と detail recommendation の一部が含まれることを確認

## Screenshot

未取得です。現在のCodex in-app browserからローカルdev serverへ到達できないため、HTTP/HTML確認とbuildで検証しました。

Closes #49