### PR TITLE
fix(frontend): refresh primary recommendation copy

### DIFF
--- a/frontend/app/data/bottle-recommendations.ts
+++ b/frontend/app/data/bottle-recommendations.ts
@@ -11,9 +11,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   lagavulin16yearold: {
     bottleId: "lagavulin16yearold",
     cardRecommendation:
-      "深いスモークや余韻をゆっくり楽しみたい夜に。強い味わいへ進みたいときの候補です。",
+      "スモーキーさを残しつつ、ゆっくり飲む満足感を広げやすい一本。",
     detailRecommendation:
-      "しっかりしたピートや潮気のある味が好きなら、この方向は次の一本の手がかりになります。食後に少し時間をかけて、濃い余韻を楽しみたい日に向いています。",
+      "「重めのスモーキー系」が好きならかなり近い方向。厚みのある甘さもあるので、休日にじっくり飲みたい日にも向いています。",
     directionTags: ["smoky", "coastal", "rich"],
     moodTags: ["quiet-night", "after-dinner", "slow-drink"],
     sceneTags: ["solo-drink", "deep-smoke", "nightcap"],
@@ -21,9 +21,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   ardbeg10yearold: {
     bottleId: "ardbeg10yearold",
     cardRecommendation:
-      "はっきりしたスモークを試したいならこの方向。力強い一本に進みたい日に合います。",
+      "「煙感強め・ドライ寄り」が好きならかなり近い方向。",
     detailRecommendation:
-      "スモーキーさをもっと前に出したいときに選びやすい候補です。甘さよりもピートやドライな余韻を楽しみたい夜の手がかりになります。",
+      "しっかりした煙感は欲しいけど、甘さは控えめにしたい人向け。キレもあるので、ハイボールでも楽しみやすい一本です。",
     directionTags: ["smoky", "peaty", "dry"],
     moodTags: ["adventurous", "quiet-night", "slow-drink"],
     sceneTags: ["bold-smoke", "solo-drink", "after-dinner"],
@@ -31,9 +31,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   bowmore12yearold: {
     bottleId: "bowmore12yearold",
     cardRecommendation:
-      "やわらかなスモークから入りたいときに。アイラらしさを穏やかに試せる候補です。",
+      "スモーキーさを少しやわらかめに楽しみたい時向け。",
     detailRecommendation:
-      "スモーキーな方向に興味はあるけれど、強すぎる味は少し不安なときに見やすい一本です。潮気や甘さもあり、最初のアイラ候補としても使いやすい手がかりになります。",
+      "「ピート系は気になるけど、重すぎるのは避けたい」人にも入りやすい方向。ほどよい甘さもあるので、夜にゆっくり飲みたい日にも合います。",
     directionTags: ["smoky", "coastal", "gentle"],
     moodTags: ["relaxing", "rainy-day", "slow-drink"],
     sceneTags: ["first-islay", "home-drink", "bar-time"],
@@ -41,9 +41,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   talisker10yearold: {
     bottleId: "talisker10yearold",
     cardRecommendation:
-      "潮気やスパイス感がほしい日に。甘さだけではない一本へ進みたいときの候補です。",
+      "スモーキーさを残しつつ、キレを楽しみやすい方向。",
     detailRecommendation:
-      "果実の甘さよりも、潮気や黒胡椒のような刺激を少し足したいときに向いています。ハイボールでも個性が残りやすく、気分を切り替えたい日の手がかりになります。",
+      "「煙感は欲しいけど、重たすぎるのは避けたい」人向け。スパイシーさもあるので、食事と合わせたい日にも向いています。",
     directionTags: ["coastal", "spicy", "smoky"],
     moodTags: ["rainy-day", "refreshing", "slow-drink"],
     sceneTags: ["highball", "solo-drink", "bar-time"],
@@ -51,9 +51,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   springbank10yearold: {
     bottleId: "springbank10yearold",
     cardRecommendation:
-      "素朴さや奥行きのある味を探したいときに。少し通好みの方向へ進む候補です。",
+      "少しクセ感のあるモルトを広げたい時にも試しやすい一本。",
     detailRecommendation:
-      "きれいに整いすぎた味よりも、香ばしさやオイリーさのある表情を楽しみたい日に合います。ゆっくり飲みながら変化を見る一本として使いやすい手がかりです。",
+      "「香ばしさやモルト感」をしっかり楽しみたい人向け。スモーキーさも軽く感じられるので、いつもの方向を少し広げたい時にも合います。",
     directionTags: ["oily", "coastal", "complex"],
     moodTags: ["slow-drink", "quiet-night", "curious"],
     sceneTags: ["solo-drink", "deep-dive", "after-dinner"],
@@ -61,9 +61,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   arran10yearold: {
     bottleId: "arran10yearold",
     cardRecommendation:
-      "明るい果実感と軽やかさを探す日に。重すぎない一本へ進みたいときの候補です。",
+      "フルーティさを軽やかに楽しみたい日に向いた方向。",
     detailRecommendation:
-      "華やかな果実感やモルトの甘さを、気軽に楽しみたいときに見やすい一本です。強いスモークよりも、明るく飲み進めやすい方向を探す手がかりになります。",
+      "「華やか系を飲みたいけど、重すぎる甘さは避けたい」人にも試しやすいタイプ。軽やかなので、食後に一杯だけ飲みたい日にも向いています。",
     directionTags: ["fruity", "light", "malty"],
     moodTags: ["relaxing", "fresh-start", "easy-night"],
     sceneTags: ["home-drink", "first-single-malt", "casual"],
@@ -71,9 +71,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   glenfarclas12yearold: {
     bottleId: "glenfarclas12yearold",
     cardRecommendation:
-      "シェリー樽の甘みをゆっくり楽しみたい日に。食後の一杯として見やすい候補です。",
+      "濃いめの甘さを、ゆっくり楽しみたい日に向いた一本。",
     detailRecommendation:
-      "ドライフルーツやナッツのような甘さが好きなら、この方向は次の一本の手がかりになります。強いスモークよりも、落ち着いた甘みを食後に楽しみたい日に向いています。",
+      "「シェリー系のコク」をしっかり楽しみたい人向け。重たすぎずまとまりもあるので、休日にゆっくり飲みたい時にも試しやすいです。",
     directionTags: ["sherry", "sweet", "nutty"],
     moodTags: ["after-dinner", "quiet-night", "slow-drink"],
     sceneTags: ["dessert-pairing", "home-drink", "nightcap"],
@@ -81,9 +81,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   glenfiddich12yearold: {
     bottleId: "glenfiddich12yearold",
     cardRecommendation:
-      "青りんごのような軽さを探す日に。すっきりしたシングルモルト候補です。",
+      "軽やかなフルーティ系を自然に試しやすい方向。",
     detailRecommendation:
-      "重い樽感よりも、軽やかな果実感や飲みやすさを優先したいときに見やすい一本です。最初のシングルモルトや、気軽に開けたい夜の手がかりになります。",
+      "「飲みやすいシングルモルト」を探している人にも入りやすいタイプ。すっきりした方向なので、普段ハイボール中心の人にも合いやすいです。",
     directionTags: ["fruity", "light", "fresh"],
     moodTags: ["relaxing", "fresh-start", "easy-night"],
     sceneTags: ["first-single-malt", "home-drink", "casual"],
@@ -91,9 +91,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   themacallan12yearold: {
     bottleId: "themacallan12yearold",
     cardRecommendation:
-      "上品な甘みや樽の深みを探す日に。少し特別感のある候補です。",
+      "甘さとコクを、ゆっくり広げたい日に向いた方向。",
     detailRecommendation:
-      "シェリー樽由来の甘みや落ち着いた厚みを楽しみたいときに見やすい一本です。にぎやかに飲むより、食後にゆっくり味を確かめたい日の手がかりになります。",
+      "「濃いめの甘さ」をしっかり楽しみたい人向け。重厚すぎず飲みやすさもあるので、食後にゆっくり飲みたい日にも合います。",
     directionTags: ["sherry", "elegant", "rich"],
     moodTags: ["after-dinner", "celebratory", "slow-drink"],
     sceneTags: ["special-night", "gift-idea", "nightcap"],
@@ -101,9 +101,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   benromach10yearold: {
     bottleId: "benromach10yearold",
     cardRecommendation:
-      "甘さに少しスモークを足したいときに。クラシックな方向へ進む候補です。",
+      "スモーキーさを少し香ばしめに広げやすいタイプ。",
     detailRecommendation:
-      "シェリーの甘みだけでは少し物足りない日に、やさしいピート感を足す手がかりになります。派手すぎず、食後や静かな夜にじっくり試しやすい一本です。",
+      "「軽めのピート感」が好きなら自然に試しやすい方向。モルトの甘さも感じやすいので、夜にゆっくり飲みたい日にも向いています。",
     directionTags: ["sherry", "smoky", "classic"],
     moodTags: ["quiet-night", "after-dinner", "slow-drink"],
     sceneTags: ["home-drink", "classic-malt", "solo-drink"],


### PR DESCRIPTION
## Summary

主要10本の recommendation 文を、指定された文体ガイド準拠テキストへ差し替えました。

## What changed

- `frontend/app/data/bottle-recommendations.ts` の `cardRecommendation` / `detailRecommendation` のみ差し替え
- 対象10本
  - Lagavulin 16
  - Ardbeg 10
  - Bowmore 12
  - Talisker 10
  - Springbank 10
  - Arran 10
  - Glenfarclas 12
  - Glenfiddich 12
  - The Macallan 12
  - Benromach 10
- `directionTags` / `moodTags` / `sceneTags` は変更していません
- UI構造、recommendation logic、DB接続、自動生成は変更していません

## Validation

- `npm.cmd run build` 成功
- 差分が `frontend/app/data/bottle-recommendations.ts` の文言差し替えのみであることを確認

## Screenshot

N/A

Refs #49