### PR TITLE
[OCR/API] 画像表示されたボトル写真でもOCR検証できるようにする

### DIFF
--- a/frontend/app/api/ocr/route.ts
+++ b/frontend/app/api/ocr/route.ts
@@ -6,10 +6,16 @@ export const maxDuration = 30;
 
 type OcrSuccessResponse = {
   text: string;
+  status: "ok" | "no_text";
+  userMessage?: string;
+  retryHint?: string;
 };
 
 type OcrErrorCode =
   | "invalid_request"
+  | "image_empty"
+  | "image_too_large"
+  | "image_read_failed"
   | "vision_auth_failed"
   | "vision_config_missing"
   | "vision_config_invalid"
@@ -20,9 +26,19 @@ type OcrErrorResponse = {
   error: string;
   code?: OcrErrorCode;
   details?: string;
+  userMessage: string;
+  retryHint?: string;
+  recoverable: boolean;
 };
 
 let visionClient: ImageAnnotatorClient | null = null;
+
+const MAX_IMAGE_SIZE_BYTES = 20 * 1024 * 1024;
+const OCR_RETRY_MESSAGE = "読み取れませんでした";
+const OCR_RETRY_HINT =
+  "ラベルが見えるように、明るさや角度を変えてもう一度撮影してください。";
+const OCR_SERVICE_MESSAGE =
+  "読み取り処理が一時的にうまくいきませんでした。時間をおいて再度お試しください。";
 
 class OcrConfigError extends Error {
   constructor(
@@ -147,25 +163,69 @@ function jsonError(
   status: number,
   code?: OcrErrorCode,
   details?: string,
+  userMessage = OCR_RETRY_MESSAGE,
+  retryHint?: string,
+  recoverable = true,
 ) {
-  const safeMessage = details ? `${message} ${details}` : message;
-
   return NextResponse.json<OcrErrorResponse>(
-    { error: safeMessage, code, details },
+    { error: message, code, details, userMessage, retryHint, recoverable },
     { status },
   );
 }
 
 function classifyOcrError(error: unknown): {
   code: OcrErrorCode;
+  status: number;
   details: string;
+  userMessage: string;
+  retryHint?: string;
+  recoverable: boolean;
 } {
   if (error instanceof OcrConfigError) {
-    return { code: error.code, details: error.message };
+    return {
+      code: error.code,
+      status: 500,
+      details: error.message,
+      userMessage: OCR_SERVICE_MESSAGE,
+      recoverable: false,
+    };
   }
 
   const message = error instanceof Error ? error.message : String(error);
   const lowerMessage = message.toLowerCase();
+
+  if (
+    lowerMessage.includes("invalid image") ||
+    lowerMessage.includes("bad image") ||
+    lowerMessage.includes("unsupported image") ||
+    lowerMessage.includes("image decode") ||
+    lowerMessage.includes("invalid_argument")
+  ) {
+    return {
+      code: "image_read_failed",
+      status: 422,
+      details:
+        "Google Vision could not read the uploaded image payload as an OCR target.",
+      userMessage: OCR_RETRY_MESSAGE,
+      retryHint: OCR_RETRY_HINT,
+      recoverable: true,
+    };
+  }
+
+  if (
+    lowerMessage.includes("payload") ||
+    lowerMessage.includes("too large") ||
+    lowerMessage.includes("request entity")
+  ) {
+    return {
+      code: "image_too_large",
+      status: 413,
+      details: "The uploaded image was too large for OCR processing.",
+      userMessage: "画像が大きすぎるため読み取れませんでした",
+      retryHint: "少し小さめに撮影するか、画像サイズを下げて再度お試しください。",
+      recoverable: true,
+    };
+  }
 
   if (
     lowerMessage.includes("private key") ||
@@ -176,8 +236,11 @@ function classifyOcrError(error: unknown): {
   ) {
     return {
       code: "vision_auth_failed",
+      status: 500,
       details:
         "Google Vision authentication failed. Check the Vercel service account JSON and private_key newline formatting.",
+      userMessage: OCR_SERVICE_MESSAGE,
+      recoverable: false,
     };
   }
 
@@ -187,15 +250,22 @@ function classifyOcrError(error: unknown): {
   ) {
     return {
       code: "vision_permission_denied",
+      status: 500,
       details:
         "Google Vision rejected the request. Check that the Vision API is enabled and the service account has access.",
+      userMessage: OCR_SERVICE_MESSAGE,
+      recoverable: false,
     };
   }
 
   return {
     code: "vision_request_failed",
+    status: 502,
     details:
       "Google Vision request failed. Check Vercel Function Logs for the safe OCR diagnostic entry.",
+    userMessage: OCR_RETRY_MESSAGE,
+    retryHint: OCR_RETRY_HINT,
+    recoverable: true,
   };
 }
 
@@ -209,11 +279,47 @@ export async function POST(request: Request) {
         "Send an image file in the image field.",
         400,
         "invalid_request",
+        undefined,
+        "画像ファイルを選択してください",
+        undefined,
+        true,
       );
     }
 
     if (!image.type.startsWith("image/")) {
-      return jsonError("Only image files are supported.", 400, "invalid_request");
+      return jsonError(
+        "Only image files are supported.",
+        400,
+        "invalid_request",
+        undefined,
+        "画像ファイルを選択してください",
+        "JPEG、PNG、HEICなどの画像を選んでください。",
+        true,
+      );
+    }
+
+    if (image.size <= 0) {
+      return jsonError(
+        "The uploaded image file was empty.",
+        400,
+        "image_empty",
+        undefined,
+        "画像を読み取れませんでした",
+        "別の画像を選んで再度お試しください。",
+        true,
+      );
+    }
+
+    if (image.size > MAX_IMAGE_SIZE_BYTES) {
+      return jsonError(
+        "The uploaded image file was too large.",
+        413,
+        "image_too_large",
+        `${image.size} bytes`,
+        "画像が大きすぎるため読み取れませんでした",
+        "少し小さめに撮影するか、画像サイズを下げて再度お試しください。",
+        true,
+      );
     }
 
     console.info("[OCR] textDetection request:", {
@@ -231,15 +337,33 @@ export async function POST(request: Request) {
     const text = result.textAnnotations?.[0]?.description?.trim() ?? "";
     console.log("[OCR] textDetection result:", text);
 
-    return NextResponse.json<OcrSuccessResponse>({ text });
+    if (!text) {
+      return NextResponse.json<OcrSuccessResponse>({
+        text: "",
+        status: "no_text",
+        userMessage: OCR_RETRY_MESSAGE,
+        retryHint: OCR_RETRY_HINT,
+      });
+    }
+
+    return NextResponse.json<OcrSuccessResponse>({ text, status: "ok" });
   } catch (error) {
-    const { code, details } = classifyOcrError(error);
+    const { code, status, details, userMessage, retryHint, recoverable } =
+      classifyOcrError(error);
     console.error("[OCR] textDetection failed:", {
       code,
       details,
       message: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    return jsonError("OCR processing failed.", 500, code, details);
+    return jsonError(
+      "OCR processing failed.",
+      status,
+      code,
+      details,
+      userMessage,
+      retryHint,
+      recoverable,
+    );
   }
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -448,6 +448,8 @@ button {
   color: #ffad93;
   font-size: 0.82rem;
   font-weight: 700;
+  line-height: 1.55;
+  white-space: pre-line;
 }
 
 .resultCard {

--- a/frontend/app/scan-uploader.tsx
+++ b/frontend/app/scan-uploader.tsx
@@ -10,7 +10,25 @@ import {
 
 type OcrResponse = {
   text: string;
+  status?: "ok" | "no_text";
+  userMessage?: string;
+  retryHint?: string;
 };
+
+type OcrFailureResponse = {
+  error?: string;
+  code?: string;
+  userMessage?: string;
+  retryHint?: string;
+  recoverable?: boolean;
+};
+
+function formatOcrFailureMessage(
+  response?: Pick<OcrResponse | OcrFailureResponse, "userMessage" | "retryHint">,
+) {
+  const message = response?.userMessage ?? "読み取れませんでした";
+  return response?.retryHint ? `${message}\n${response.retryHint}` : message;
+}
 
 export function ScanUploader() {
   const [file, setFile] = useState<File | null>(null);
@@ -59,13 +77,22 @@ export function ScanUploader() {
       console.log("OCR response:", data);
 
       if (!response.ok) {
-        setError(data.error ?? "OCR に失敗しました。");
+        setError(formatOcrFailureMessage(data as OcrFailureResponse));
         return;
       }
 
-      setOcrResult(data as OcrResponse);
+      const ocrData = data as OcrResponse;
+
+      if (ocrData.status === "no_text" || !ocrData.text?.trim()) {
+        setError(formatOcrFailureMessage(ocrData));
+        return;
+      }
+
+      setOcrResult(ocrData);
     } catch {
-      setError("API に接続できませんでした。");
+      setError(
+        "読み取り処理に接続できませんでした。時間をおいて再度お試しください。",
+      );
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## Summary

Closes #54.

モニタや別端末に表示したボトル画像をスマホで撮影したケースでも、OCR導線が `API error` 表示だけで止まらないようにしました。OCRできない画像やVision API側の失敗を、ユーザー向けの通常失敗状態として扱えるようにしています。

## What changed

- `frontend/app/api/ocr/route.ts`
  - OCR成功レスポンスに `status` を追加
  - OCRテキストなしを `status: "no_text"` の通常失敗状態として返却
  - 非画像、空画像、サイズ超過、画像読み取り失敗、Vision API失敗をコード別に分類
  - API内部向け `error/details` と、画面表示向け `userMessage/retryHint` を分離
- `frontend/app/scan-uploader.tsx`
  - API失敗時に `data.error` をそのまま表示せず、`userMessage` / `retryHint` を表示
  - 200レスポンスでもOCRテキストが空の場合は結果カードへ進めず、通常の読み取り失敗として表示
  - fetch例外時も `API error` ではなくユーザー向けの再試行案内を表示
- `frontend/app/globals.css`
  - OCR失敗メッセージが2行でも読みやすいように行間と改行表示を調整

## Validation

- `npm.cmd run build` 成功
- API route response確認
  - 非画像ファイルを `/api/ocr` に送信: `400` / `code: invalid_request` / `userMessage: 画像ファイルを選択してください`
  - 1px PNGを `/api/ocr` に送信: ローカル環境ではVision API通信が失敗し、`502` / `code: vision_request_failed` / `userMessage: 読み取れませんでした` / `retryHint: ラベルが見えるように、明るさや角度を変えてもう一度撮影してください。`
- Page response確認
  - `GET /` が `200` を返すことを確認
  - ホームHTML内にscan導線関連のテキストが含まれることを確認
- `git diff --check` 成功

確認できた原因またはレスポンス内容:

- ローカル検証では、画像自体はAPI routeまで届いていました。
- Vision API呼び出し時に通信失敗が発生し、従来はフロントでAPI失敗として見えやすい状態でした。
- 今回はVision API側の失敗を `vision_request_failed` として分類し、ユーザーには通常の読み取り失敗メッセージを返すようにしました。

OCR失敗とAPI失敗の切り分け:

- OCRできた場合: `status: ok` とOCRテキストを返す
- OCRテキストが空の場合: `200` / `status: no_text` / ユーザー向け再撮影案内を返す
- 画像入力として不正な場合: `400` または `413` の構造化エラーを返す
- Vision APIや認証・通信の失敗: `vision_*` 系コードで分類し、画面には `userMessage` / `retryHint` を表示する

検証画像・条件:

- 非画像のテキストBlobをアップロードして入力バリデーションを確認
- 1px PNGをアップロードしてVision API失敗時の構造化レスポンスを確認
- 実物ボトルやモニタ撮影画像での実機OCR検証は、Vercel Preview反映後のスマホ実機確認で行う想定

## Screenshot

N/A

開発環境ではスクリーンショット取得が安定しないため、AGENTS.mdの運用ルールに沿って添付していません。UI関連の確認はbuild、route/page response、key text/HTML確認まで実施し、見た目はVercelデプロイ後にスマホ実機で確認する想定です。
