### PR TITLE
[MVP] ボトル詳細画面のおすすめ理由表示をrecommendationデータに統一する

### DIFF
--- a/frontend/app/bottles/[slug]/page.tsx
+++ b/frontend/app/bottles/[slug]/page.tsx
@@ -35,6 +35,12 @@ export default async function BottleDetailPage({ params }: BottleDetailPageProps
   }
 
   const regionDescription = getRegionDescription(bottle.region);
+  const detailRecommendation = bottle.recommendation?.detailRecommendation;
+  const fallbackRecommendationReasons = detailRecommendation
+    ? []
+    : bottle.recommendationReasons;
+  const hasRecommendationReason =
+    Boolean(detailRecommendation) || fallbackRecommendationReasons.length > 0;
 
   return (
     <main className="appShell detailShell">
@@ -65,23 +71,19 @@ export default async function BottleDetailPage({ params }: BottleDetailPageProps
         <p>{bottle.tasteProfile}</p>
       </section>
 
-      {bottle.recommendation ? (
-        <section className="detailCard" aria-labelledby="recommendation-title">
-          <p className="sectionKicker">Next Bottle</p>
-          <h2 id="recommendation-title">次の一本として見るなら</h2>
-          <p>{bottle.recommendation.detailRecommendation}</p>
-        </section>
-      ) : null}
-
-      {bottle.recommendationReasons.length > 0 ? (
+      {hasRecommendationReason ? (
         <section className="detailCard" aria-labelledby="reason-title">
           <p className="sectionKicker">Reason</p>
           <h2 id="reason-title">おすすめ理由</h2>
-          <ul className="reasonList">
-            {bottle.recommendationReasons.map((reason) => (
-              <li key={reason}>{reason}</li>
-            ))}
-          </ul>
+          {detailRecommendation ? (
+            <p>{detailRecommendation}</p>
+          ) : (
+            <ul className="reasonList">
+              {fallbackRecommendationReasons.map((reason) => (
+                <li key={reason}>{reason}</li>
+              ))}
+            </ul>
+          )}
         </section>
       ) : null}
 


### PR DESCRIPTION
## Summary

Closes #58.

ボトル詳細画面の「おすすめ理由」表示で、既存の `detailRecommendation` を優先して表示するように整理しました。recommendation文の新規作成・変更・短縮・拡張は行っていません。

## What changed

- `frontend/app/bottles/[slug]/page.tsx`
  - `bottle.recommendation?.detailRecommendation` を詳細画面のおすすめ理由として優先表示
  - `detailRecommendation` がない場合のみ、既存の `recommendationReasons` のリスト表示へフォールバック
  - これまで分かれていた `Next Bottle` セクションと `Reason` セクションを、表示目的に合わせて `Reason / おすすめ理由` に統一

## Validation

- `npm.cmd run build` 成功
- key text / HTML presence確認
  - 主要10本すべての詳細ページを `GET /bottles/{slug}` で確認
  - `detailRecommendation` がHTMLに含まれることを、`frontend/app/data/bottle-recommendations.ts` の既存文字列と照合
  - `Reason` セクションがHTMLに含まれることを確認
- 確認結果
  - Lagavulin 16: `200 detail-ok reason-ok`
  - Ardbeg 10: `200 detail-ok reason-ok`
  - Bowmore 12: `200 detail-ok reason-ok`
  - Talisker 10: `200 detail-ok reason-ok`
  - Springbank 10: `200 detail-ok reason-ok`
  - Arran 10: `200 detail-ok reason-ok`
  - Glenfarclas 12: `200 detail-ok reason-ok`
  - Glenfiddich 12: `200 detail-ok reason-ok`
  - The Macallan 12: `200 detail-ok reason-ok`
  - Benromach 10: `200 detail-ok reason-ok`
- `git diff --check` 成功

原因:

- 詳細画面では `detailRecommendation` が `Next Bottle` セクションに表示され、`おすすめ理由` セクションは `recommendationReasons.length > 0` の場合のみ表示されていました。
- Glenfiddich 12 / The Macallan 12 / Benromach 10 は `detailRecommendation` は存在する一方で `recommendationReasons` が空のため、「おすすめ理由」としては表示されていないように見える状態でした。

表示優先順位:

1. `bottle.recommendation?.detailRecommendation`
2. `bottle.recommendationReasons`

## Screenshot

N/A

スクリーンショット取得は開発環境で安定しないため、AGENTS.mdの運用ルールに沿って添付していません。今回はUI構造の大改修ではなく表示参照先の整理のため、buildとHTML presenceで確認しています。