### PR TITLE
[OCR/Data] Lagavulin 16 が Port Ellen として候補表示される問題を調整する

### DIFF
--- a/frontend/app/lib/ocr-distillery.ts
+++ b/frontend/app/lib/ocr-distillery.ts
@@ -15,16 +15,84 @@ export function normalizeOcrText(text: string) {
   return text.replace(/\s+/g, " ").trim().toLowerCase();
 }
 
+function compactText(text: string) {
+  return text.replace(/[^a-z0-9]+/g, "");
+}
+
+function getBottleAgeMarker(name: string) {
+  return name.match(/\b(\d{2})\b/)?.[1];
+}
+
+function hasNearbyAgeMarker(text: string, distilleryName: string, age: string) {
+  const pattern = new RegExp(
+    `${distilleryName.toLowerCase()}[^a-z0-9]{0,24}${age}`,
+    "i",
+  );
+  return pattern.test(text);
+}
+
+function hasAgeMarker(text: string, age: string) {
+  return new RegExp(`\\b${age}\\b`).test(text);
+}
+
+function scoreDistilleryCandidate(
+  distillery: Distillery,
+  normalizedText: string,
+) {
+  const compactOcrText = compactText(normalizedText);
+  let score = 0;
+
+  if (normalizedText.includes(distillery.name.toLowerCase())) {
+    score += 100;
+  }
+
+  for (const keyword of distillery.keywords) {
+    if (normalizedText.includes(keyword.toLowerCase())) {
+      score += 70;
+    }
+  }
+
+  for (const bottle of distillery.bottles) {
+    const normalizedBottleName = bottle.name.toLowerCase();
+
+    if (normalizedText.includes(normalizedBottleName)) {
+      score += 150;
+    }
+
+    if (compactOcrText.includes(compactText(normalizedBottleName))) {
+      score += 120;
+    }
+
+    const age = getBottleAgeMarker(bottle.name);
+
+    if (age && hasNearbyAgeMarker(normalizedText, distillery.name, age)) {
+      score += 80;
+    }
+
+    if (
+      age &&
+      normalizedText.includes(distillery.name.toLowerCase()) &&
+      hasAgeMarker(normalizedText, age)
+    ) {
+      score += 40;
+    }
+  }
+
+  return score;
+}
+
 export function findDistilleryCandidate(text: string): DistilleryCandidate {
   if (!text) {
     return unknownDistillery;
   }
 
-  return (
-    distilleries.find((distillery) =>
-      [distillery.name, ...distillery.keywords].some((keyword) =>
-        text.includes(keyword.toLowerCase()),
-      ),
-    ) ?? unknownDistillery
-  );
+  const candidates = distilleries
+    .map((distillery) => ({
+      distillery,
+      score: scoreDistilleryCandidate(distillery, text),
+    }))
+    .filter((candidate) => candidate.score > 0)
+    .sort((current, next) => next.score - current.score);
+
+  return candidates[0]?.distillery ?? unknownDistillery;
 }


### PR DESCRIPTION
## Summary

Closes #60.

Lagavulin 16 のOCRテキストに `Lagavulin` と副次情報の `Port Ellen` が含まれる場合に、配列順で `Port Ellen` が主候補になり得る問題を、候補判定レイヤーの軽いスコアリングで調整しました。

## What changed

- `frontend/app/lib/ocr-distillery.ts`
  - 既存の「最初にキーワード一致した蒸留所を返す」方式を、候補ごとのスコアリング方式へ変更
  - 蒸留所名一致を加点
  - keywords一致を加点
  - bottle name一致を加点
  - `Lagavulin` と `16` のように、蒸留所名とボトル年数が同じOCRテキスト内にある場合を加点

## Validation

- `npm.cmd run build` 成功
- 候補判定確認用の一時スクリプトで以下を確認し、スクリプトは削除済み
  - `Lagavulin Islay Single Malt Scotch Whisky Aged 16 Years Port Ellen` => `Lagavulin`
  - `Arran 10 Year Old Single Malt` => `Isle of Arran`
  - `Bowmore 12 Year Old Islay Single Malt` => `Bowmore`
  - `Talisker 10 Year Old Isle of Skye` => `Talisker`
  - `Glenfarclas 12 Year Old Speyside` => `Glenfarclas`
  - `Glenfiddich 12 Year Old Single Malt` => `Glenfiddich`
  - `The Macallan 12 Year Old` => `Macallan`
  - `Benromach 10 Year Old Speyside` => `Benromach`
- `git diff --check` 成功

## Cause

従来の `findDistilleryCandidate` は `distilleries.find(...)` で、配列順に最初に一致した蒸留所を返していました。

`distilleries.ts` では `Port Ellen` が `Lagavulin` より前に定義されているため、OCRテキストに両方が含まれると、副次情報の `Port Ellen` が主候補として優先される可能性がありました。

## Candidate Priority Change

変更前:

1. `distilleries` 配列順で最初に一致した候補
2. キーワード一致があれば即採用

変更後:

1. 候補をすべてスコアリング
2. 蒸留所名 / keyword / bottle name / 年数手がかりを加点
3. 最高スコアの候補を採用

Lagavulin 16 の想定OCRでは、`Port Ellen` は地名・副次情報として名前一致のみになります。一方で `Lagavulin` は蒸留所名に加えて `16` のボトル年数手がかりも拾えるため、Lagavulinが優先候補になります。

## Screenshot

N/A

スクリーンショット取得は開発環境で安定しないため、AGENTS.mdの運用ルールに沿って添付していません。今回はUI構造変更ではなく候補判定ロジックの調整のため、buildと候補判定スクリプトで確認しています。