### PR TITLE
[OCR/Data] OCR bounding boxを使って主ラベル情報の候補優先度を補正する

### DIFF
--- a/frontend/app/api/ocr/route.ts
+++ b/frontend/app/api/ocr/route.ts
@@ -7,8 +7,17 @@ export const maxDuration = 30;
 type OcrSuccessResponse = {
   text: string;
   status: "ok" | "no_text";
+  annotations?: OcrTextAnnotation[];
   userMessage?: string;
   retryHint?: string;
+};
+
+type OcrTextAnnotation = {
+  description: string;
+  vertices?: {
+    x: number;
+    y: number;
+  }[];
 };
 
 type OcrErrorCode =
@@ -199,6 +208,25 @@ function jsonError(
   );
 }
 
+function getOcrTextAnnotations(
+  textAnnotations: NonNullable<
+    Awaited<ReturnType<ImageAnnotatorClient["textDetection"]>>[0]["textAnnotations"]
+  >,
+) {
+  return textAnnotations
+    .slice(1)
+    .map((annotation) => ({
+      description: annotation.description?.trim() ?? "",
+      vertices: annotation.boundingPoly?.vertices
+        ?.map((vertex) => ({
+          x: Number(vertex.x ?? 0),
+          y: Number(vertex.y ?? 0),
+        }))
+        .filter((vertex) => Number.isFinite(vertex.x) && Number.isFinite(vertex.y)),
+    }))
+    .filter((annotation) => annotation.description);
+}
+
 function classifyOcrError(error: unknown): {
   code: OcrErrorCode;
   status: number;
@@ -360,19 +388,26 @@ export async function POST(request: Request) {
       image: { content: imageBuffer.toString("base64") },
     });
 
-    const text = result.textAnnotations?.[0]?.description?.trim() ?? "";
+    const textAnnotations = result.textAnnotations ?? [];
+    const text = textAnnotations[0]?.description?.trim() ?? "";
+    const annotations = getOcrTextAnnotations(textAnnotations);
     console.log("[OCR] textDetection result:", text);
 
     if (!text) {
       return NextResponse.json<OcrSuccessResponse>({
         text: "",
         status: "no_text",
+        annotations,
         userMessage: OCR_RETRY_MESSAGE,
         retryHint: OCR_RETRY_HINT,
       });
     }
 
-    return NextResponse.json<OcrSuccessResponse>({ text, status: "ok" });
+    return NextResponse.json<OcrSuccessResponse>({
+      text,
+      status: "ok",
+      annotations,
+    });
   } catch (error) {
     const { code, status, details, userMessage, retryHint, recoverable } =
       classifyOcrError(error);

--- a/frontend/app/lib/ocr-distillery.ts
+++ b/frontend/app/lib/ocr-distillery.ts
@@ -5,6 +5,14 @@ export type DistilleryCandidate = Pick<
   "name" | "region" | "bottles"
 >;
 
+export type OcrTextAnnotation = {
+  description: string;
+  vertices?: {
+    x: number;
+    y: number;
+  }[];
+};
+
 export const unknownDistillery: DistilleryCandidate = {
   name: "Unknown",
   region: "Unknown",
@@ -17,6 +25,18 @@ export function normalizeOcrText(text: string) {
 
 function compactText(text: string) {
   return text.replace(/[^a-z0-9]+/g, "");
+}
+
+function matchesText(value: string, target: string) {
+  const normalizedValue = value.toLowerCase();
+  const normalizedTarget = target.toLowerCase();
+  const compactValue = compactText(normalizedValue);
+  const compactTarget = compactText(normalizedTarget);
+
+  return (
+    normalizedValue.includes(normalizedTarget) ||
+    (compactTarget.length > 0 && compactValue.includes(compactTarget))
+  );
 }
 
 function getBottleAgeMarker(name: string) {
@@ -35,12 +55,131 @@ function hasAgeMarker(text: string, age: string) {
   return new RegExp(`\\b${age}\\b`).test(text);
 }
 
+function getAnnotationBox(annotation: OcrTextAnnotation) {
+  const vertices = annotation.vertices?.filter(
+    (vertex) => Number.isFinite(vertex.x) && Number.isFinite(vertex.y),
+  );
+
+  if (!vertices || vertices.length === 0) {
+    return null;
+  }
+
+  const xs = vertices.map((vertex) => vertex.x);
+  const ys = vertices.map((vertex) => vertex.y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const width = Math.max(0, maxX - minX);
+  const height = Math.max(0, maxY - minY);
+
+  if (width === 0 || height === 0) {
+    return null;
+  }
+
+  return {
+    minX,
+    maxX,
+    minY,
+    maxY,
+    width,
+    height,
+    area: width * height,
+    centerX: minX + width / 2,
+    centerY: minY + height / 2,
+  };
+}
+
+function getAnnotationLayout(annotations: OcrTextAnnotation[]) {
+  const boxes = annotations
+    .map((annotation) => getAnnotationBox(annotation))
+    .filter((box) => box !== null);
+
+  if (boxes.length === 0) {
+    return null;
+  }
+
+  const minX = Math.min(...boxes.map((box) => box.minX));
+  const maxX = Math.max(...boxes.map((box) => box.maxX));
+  const minY = Math.min(...boxes.map((box) => box.minY));
+  const maxY = Math.max(...boxes.map((box) => box.maxY));
+  const width = Math.max(1, maxX - minX);
+  const height = Math.max(1, maxY - minY);
+
+  return {
+    minX,
+    minY,
+    width,
+    height,
+    area: width * height,
+    centerX: minX + width / 2,
+    centerY: minY + height / 2,
+  };
+}
+
+function annotationMatchesDistillery(
+  annotation: OcrTextAnnotation,
+  distillery: Distillery,
+) {
+  return (
+    matchesText(annotation.description, distillery.name) ||
+    distillery.keywords.some((keyword) =>
+      matchesText(annotation.description, keyword),
+    ) ||
+    distillery.bottles.some((bottle) =>
+      matchesText(annotation.description, bottle.name),
+    )
+  );
+}
+
+function scoreAnnotationVisualWeight(
+  annotation: OcrTextAnnotation,
+  layout: NonNullable<ReturnType<typeof getAnnotationLayout>>,
+) {
+  const box = getAnnotationBox(annotation);
+
+  if (!box) {
+    return 0;
+  }
+
+  const sizeScore = Math.min(40, Math.sqrt(box.area / layout.area) * 160);
+  const widthScore = Math.min(20, (box.width / layout.width) * 80);
+  const dx = (box.centerX - layout.centerX) / (layout.width / 2);
+  const dy = (box.centerY - layout.centerY) / (layout.height / 2);
+  const centerDistance = Math.min(1, Math.sqrt(dx * dx + dy * dy));
+  const centerScore = (1 - centerDistance) * 20;
+
+  return sizeScore + widthScore + centerScore;
+}
+
+function scoreVisualCandidate(
+  distillery: Distillery,
+  annotations: OcrTextAnnotation[],
+) {
+  const layout = getAnnotationLayout(annotations);
+
+  if (!layout) {
+    return 0;
+  }
+
+  return Math.min(
+    80,
+    Math.max(
+      0,
+      ...annotations
+        .filter((annotation) => annotationMatchesDistillery(annotation, distillery))
+        .map((annotation) => scoreAnnotationVisualWeight(annotation, layout)),
+    ),
+  );
+}
+
 function scoreDistilleryCandidate(
   distillery: Distillery,
   normalizedText: string,
+  annotations: OcrTextAnnotation[],
 ) {
   const compactOcrText = compactText(normalizedText);
-  let score = 0;
+  let score = scoreVisualCandidate(distillery, annotations);
 
   if (normalizedText.includes(distillery.name.toLowerCase())) {
     score += 100;
@@ -81,7 +220,10 @@ function scoreDistilleryCandidate(
   return score;
 }
 
-export function findDistilleryCandidate(text: string): DistilleryCandidate {
+export function findDistilleryCandidate(
+  text: string,
+  annotations: OcrTextAnnotation[] = [],
+): DistilleryCandidate {
   if (!text) {
     return unknownDistillery;
   }
@@ -89,7 +231,7 @@ export function findDistilleryCandidate(text: string): DistilleryCandidate {
   const candidates = distilleries
     .map((distillery) => ({
       distillery,
-      score: scoreDistilleryCandidate(distillery, text),
+      score: scoreDistilleryCandidate(distillery, text, annotations),
     }))
     .filter((candidate) => candidate.score > 0)
     .sort((current, next) => next.score - current.score);

--- a/frontend/app/scan-uploader.tsx
+++ b/frontend/app/scan-uploader.tsx
@@ -6,11 +6,13 @@ import { ChangeEvent, FormEvent, useState } from "react";
 import {
   findDistilleryCandidate,
   normalizeOcrText,
+  type OcrTextAnnotation,
 } from "./lib/ocr-distillery";
 
 type OcrResponse = {
   text: string;
   status?: "ok" | "no_text";
+  annotations?: OcrTextAnnotation[];
   userMessage?: string;
   retryHint?: string;
 };
@@ -110,7 +112,10 @@ export function ScanUploader() {
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const normalizedText = ocrResult ? normalizeOcrText(ocrResult.text) : "";
-  const distilleryCandidate = findDistilleryCandidate(normalizedText);
+  const distilleryCandidate = findDistilleryCandidate(
+    normalizedText,
+    ocrResult?.annotations,
+  );
   const bottleCandidate = distilleryCandidate.bottles[0];
   const nextBottleRecommendation =
     bottleCandidate?.recommendation?.cardRecommendation ??


### PR DESCRIPTION
## Summary

Closes #62.

Google Vision API の `textAnnotations` に含まれる bounding box を使い、既存の文字列スコアリングに対して軽い visual score 補正を追加しました。Lagavulin専用ハードコードや Port Ellen 固定減点は行っていません。

## What changed

- `frontend/app/api/ocr/route.ts`
  - OCR成功レスポンスに annotation単位の `description` と bounding box vertices を追加
  - `textAnnotations[0]` の全文は従来通り `text` として維持
  - `textAnnotations.slice(1)` を候補判定用annotationとして返却
- `frontend/app/scan-uploader.tsx`
  - OCRレスポンスの `annotations` を候補判定へ渡すよう変更
- `frontend/app/lib/ocr-distillery.ts`
  - 既存の文字列スコアリングを維持
  - annotationが蒸留所名 / keyword / bottle name に一致した場合だけ visual score を算出
  - visual score を既存スコアへ加算
  - bounding boxがない場合は visual score 0 として従来ロジックへフォールバック

## Visual Score

使ったbounding box要素:

- 面積: 文字が大きいほど最大 +40
- 横幅: 横に広い文字ほど最大 +20
- 中央寄り: OCR annotation群の中心に近いほど最大 +20

合算方法:

- visual score は候補ごとに最大80点まで
- visual score単体で強く勝たせすぎないため、既存の文字列スコアへの補正として加算
- annotationが候補名 / keyword / bottle name に一致しない場合は加点しない

## Validation

- `npm.cmd run build` 成功
- 候補判定確認用の一時スクリプトで以下を確認し、スクリプトは削除済み
  - 実OCR相当: `LAGAVULIN 8 YEARS PORT ELLEN ISLE OF ISLAY` + 中央・大きめの `LAGAVULIN` bounding box => `Lagavulin`
  - 文字列フォールバック: `Lagavulin Islay Single Malt Scotch Whisky Aged 16 Years Port Ellen` + annotationsなし => `Lagavulin`
  - `Arran 10 Year Old Single Malt` => `Isle of Arran`
  - `Bowmore 12 Year Old Islay Single Malt` => `Bowmore`
  - `Talisker 10 Year Old Isle of Skye` => `Talisker`
  - `Glenfarclas 12 Year Old Speyside` => `Glenfarclas`
  - `Glenfiddich 12 Year Old Single Malt` => `Glenfiddich`
  - `The Macallan 12 Year Old` => `Macallan`
  - `Benromach 10 Year Old Speyside` => `Benromach`
- `git diff --check` 成功

## Lagavulin / Port Ellen Result

- 変更前: `Port Ellen` が `Lagavulin` より前に定義されているため、文字列一致条件によっては Port Ellen が主候補になりやすかった
- 変更後: OCRテキスト内に `Port Ellen` が含まれていても、`LAGAVULIN` が主ラベルらしい大きさ・中央寄りで取れている場合は Lagavulin にvisual補正が入り、Lagavulinが優先されやすくなる

## Fallback

- bounding boxがない場合、またはannotationが取得できない場合は visual score は0
- その場合はIssue #60で導入した既存の文字列スコアリングだけで候補を決定

## Screenshot

N/A

スクリーンショット取得は開発環境で安定しないため、AGENTS.mdの運用ルールに沿って添付していません。今回はUI構造変更ではなくOCR候補判定ロジックの補正のため、buildと候補判定スクリプトで確認しています。