### PR TITLE
docs: add supported bottles ledger

### DIFF
--- a/docs/SUPPORTED_BOTTLES.md
+++ b/docs/SUPPORTED_BOTTLES.md
@@ -1,0 +1,222 @@
+# Supported Bottles
+
+## Purpose
+
+This document manages Whisky-Scanner bottle support for recommendation work.
+
+Whisky-Scanner is not primarily a label-reading app. The supported bottle list is a product and implementation ledger for helping users move from "I liked this bottle" to "I might like this next."
+
+Use this document to manage:
+
+- Recommendation target coverage
+- Implementation progress
+- MVP bottle scope
+- Review progress for real-device recommendation checks
+
+This is not a general distillery directory. Include bottles because they are useful candidates for next-bottle discovery, Taste Profile learning, and MVP validation.
+
+Initial coverage is intentionally broad. It is easier to remove lower-priority candidates later than to miss likely MVP candidates early. Prefer official bottlings, core range bottles, and major ongoing products. Bottlers, single-cask releases, event-only bottles, region-only bottles, and very short-term limited releases are generally out of scope. If the classification is unclear, keep the bottle as `Planned` until product review.
+
+## Status Definitions
+
+| Status | Meaning |
+| --- | --- |
+| Planned | 対応予定 |
+| Registered | ボトルデータ登録済み |
+| Recommendation | recommendation実装済み |
+| Reviewed | 実機レビュー済み |
+
+## Islay
+
+| Distillery | Bottle | Status |
+| --- | --- | --- |
+| Ardbeg | 10 | Recommendation |
+| Ardbeg | Wee Beastie | Planned |
+| Ardbeg | An Oa | Planned |
+| Ardbeg | Uigeadail | Planned |
+| Ardbeg | Corryvreckan | Planned |
+| Lagavulin | 8 | Planned |
+| Lagavulin | 16 | Recommendation |
+| Laphroaig | 10 | Registered |
+| Laphroaig | Select | Planned |
+| Laphroaig | Quarter Cask | Planned |
+| Laphroaig | Lore | Planned |
+| Bowmore | 12 | Reviewed |
+| Bowmore | 15 | Planned |
+| Bowmore | 18 | Planned |
+| Caol Ila | 12 | Registered |
+| Caol Ila | Moch | Planned |
+| Bunnahabhain | 12 | Planned |
+| Bunnahabhain | Stiuireadair | Planned |
+| Bunnahabhain | Toiteach A Dha | Planned |
+| Bunnahabhain | 18 | Planned |
+| Kilchoman | Machir Bay | Planned |
+| Kilchoman | Sanaig | Planned |
+| Bruichladdich | The Classic Laddie | Planned |
+| Bruichladdich | Islay Barley | Planned |
+| Port Charlotte | 10 | Planned |
+| Port Charlotte | Islay Barley | Planned |
+| Octomore | .1 Series | Planned |
+| Octomore | .2 Series | Planned |
+| Octomore | .3 Series | Planned |
+
+## Campbeltown
+
+| Distillery | Bottle | Status |
+| --- | --- | --- |
+| Springbank | 10 | Recommendation |
+| Springbank | 15 | Planned |
+| Springbank | 18 | Planned |
+| Longrow | Peated | Planned |
+| Longrow | Red | Planned |
+| Hazelburn | 10 | Planned |
+| Kilkerran | 12 | Planned |
+| Kilkerran | 16 | Planned |
+| Kilkerran | Heavily Peated | Planned |
+| Glen Scotia | Campbeltown Harbour | Planned |
+| Glen Scotia | Double Cask | Planned |
+| Glen Scotia | 15 | Planned |
+| Glen Scotia | Victoriana | Planned |
+
+## Islands
+
+| Distillery | Bottle | Status |
+| --- | --- | --- |
+| Talisker | 10 | Reviewed |
+| Talisker | Skye | Planned |
+| Talisker | Storm | Planned |
+| Talisker | Port Ruighe | Planned |
+| Arran | 10 | Reviewed |
+| Arran | Barrel Reserve | Planned |
+| Arran | Quarter Cask | Planned |
+| Arran | Sherry Cask | Planned |
+| Arran | 18 | Planned |
+| Highland Park | 12 | Planned |
+| Highland Park | 15 | Planned |
+| Highland Park | 18 | Planned |
+| Highland Park | Cask Strength | Planned |
+| Jura | 10 | Planned |
+| Jura | 12 | Planned |
+| Jura | Seven Wood | Planned |
+| Tobermory | 12 | Planned |
+| Tobermory | 21 | Planned |
+| Ledaig | 10 | Planned |
+| Ledaig | 18 | Planned |
+| Ledaig | Rioja Cask | Planned |
+
+## Speyside
+
+| Distillery | Bottle | Status |
+| --- | --- | --- |
+| Glenfiddich | 12 | Reviewed |
+| Glenfiddich | 15 | Planned |
+| Glenfiddich | 18 | Planned |
+| Glenfiddich | IPA Experiment | Planned |
+| The Macallan | 12 Double Cask | Reviewed |
+| The Macallan | 12 Sherry Oak | Planned |
+| The Macallan | 15 Double Cask | Planned |
+| The Macallan | 18 Double Cask | Planned |
+| Glenfarclas | 10 | Planned |
+| Glenfarclas | 12 | Reviewed |
+| Glenfarclas | 15 | Planned |
+| Glenfarclas | 21 | Planned |
+| Glenfarclas | 105 | Planned |
+| GlenAllachie | 12 | Planned |
+| GlenAllachie | 15 | Planned |
+| GlenAllachie | 10 Cask Strength | Planned |
+| The Glenlivet | 12 | Registered |
+| The Glenlivet | Founder's Reserve | Planned |
+| The Glenlivet | 15 | Planned |
+| The Glenlivet | 18 | Planned |
+| Aberlour | 12 | Registered |
+| Aberlour | 16 | Planned |
+| Aberlour | A'bunadh | Planned |
+| Balvenie | DoubleWood 12 | Planned |
+| Balvenie | Caribbean Cask 14 | Planned |
+| Balvenie | Single Barrel 15 | Planned |
+| Balvenie | PortWood 21 | Planned |
+| Craigellachie | 13 | Planned |
+| Craigellachie | 17 | Planned |
+| Benromach | 10 | Reviewed |
+| Benromach | 15 | Planned |
+| Benromach | Peat Smoke | Planned |
+| Mortlach | 12 | Planned |
+| Mortlach | 16 | Planned |
+| Mortlach | 20 | Planned |
+
+## Highlands
+
+| Distillery | Bottle | Status |
+| --- | --- | --- |
+| Glenmorangie | The Original | Registered |
+| Glenmorangie | Lasanta | Planned |
+| Glenmorangie | Quinta Ruban | Planned |
+| Glenmorangie | Nectar d'Or | Planned |
+| Glenmorangie | 18 | Planned |
+| Oban | 14 | Planned |
+| Oban | Little Bay | Planned |
+| Clynelish | 14 | Planned |
+| Deanston | 12 | Planned |
+| Deanston | 18 | Planned |
+| Deanston | Virgin Oak | Planned |
+| Glencadam | 10 | Planned |
+| Glencadam | 15 | Planned |
+| Old Pulteney | 12 | Planned |
+| Old Pulteney | Huddart | Planned |
+| Old Pulteney | 15 | Planned |
+| Old Pulteney | 18 | Planned |
+| AnCnoc | 12 | Planned |
+| AnCnoc | 18 | Planned |
+| AnCnoc | 24 | Planned |
+| AnCnoc | Peatheart | Planned |
+| Edradour | 10 | Planned |
+| Edradour | 12 Caledonia | Planned |
+| Edradour | Ballechin 10 | Planned |
+
+## Lowlands
+
+| Distillery | Bottle | Status |
+| --- | --- | --- |
+| Auchentoshan | American Oak | Planned |
+| Auchentoshan | 12 | Planned |
+| Auchentoshan | Three Wood | Planned |
+| Glenkinchie | 12 | Planned |
+| Glenkinchie | Distillers Edition | Planned |
+
+## Ireland
+
+| Distillery | Bottle | Status |
+| --- | --- | --- |
+| Redbreast | 12 | Planned |
+| Redbreast | 12 Cask Strength | Planned |
+| Redbreast | 15 | Planned |
+| Redbreast | Lustau Edition | Planned |
+| Green Spot | Green Spot | Planned |
+| Yellow Spot | Yellow Spot 12 | Planned |
+| Teeling | Small Batch | Planned |
+| Teeling | Single Grain | Planned |
+| Teeling | Single Malt | Planned |
+| Teeling | Blackpitts | Planned |
+
+## Japan
+
+| Distillery | Bottle | Status |
+| --- | --- | --- |
+| 山崎 | Distiller's Reserve | Planned |
+| 山崎 | 12 | Planned |
+| 白州 | Distiller's Reserve | Planned |
+| 白州 | 12 | Planned |
+| 余市 | Single Malt | Planned |
+| 宮城峡 | Single Malt | Planned |
+| 知多 | Single Grain | Planned |
+| 響 | Japanese Harmony | Planned |
+
+## Future Candidates
+
+These are likely next additions after MVP scope review:
+
+- More approachable blended whiskies for highball and food-pairing recommendations
+- More Japan-market official bottles that are consistently available
+- Bourbon and rye candidates if the recommendation experience expands beyond single malt whisky
+- Additional Irish single pot still bottles for fruit, spice, and dessert-style recommendation paths
+- Availability and price-band notes for purchase support


### PR DESCRIPTION
## Summary

Adds `docs/SUPPORTED_BOTTLES.md` as a recommendation support ledger for MVP bottle coverage, implementation progress, and real-device review tracking.

## What changed

- Created `docs/SUPPORTED_BOTTLES.md`.
- Added purpose and status definitions for `Planned`, `Registered`, `Recommendation`, and `Reviewed`.
- Organized supported bottle candidates by region: Islay, Campbeltown, Islands, Speyside, Highlands, Lowlands, Ireland, and Japan.
- Added initial MVP candidates across official/core/major ongoing bottle ranges.
- Included future candidate notes for later recommendation support expansion.

## Validation

- Reviewed `AGENTS.md` and `docs/HANDOFF.md` before implementation.
- Created this docs branch from the latest `main`.
- Confirmed staged changes only included `docs/SUPPORTED_BOTTLES.md`.
- Counted initial entries: 51 distilleries and 145 bottles.
- No build run; documentation-only change.

## Screenshot

N/A