### PR TITLE
feat(frontend): add Laphroaig 10 recommendation wiring

### DIFF
--- a/docs/RECOMMENDATION_ROADMAP.md
+++ b/docs/RECOMMENDATION_ROADMAP.md
@@ -17,11 +17,11 @@ Use this document to:
 
 ## Current Coverage
 
-As of PR #70:
+After Laphroaig 10 recommendation wiring:
 
 - Supported Bottles: 168
 - Registered Bottles: 21
-- Recommendation Implemented: 10
+- Recommendation Implemented: 11
 - Reviewed: 7
 
 ## Prioritization Criteria
@@ -46,7 +46,7 @@ Highest-priority candidates for establishing Whisky-Scanner's recommendation cha
 | --- | --- | --- |
 | Ardbeg 10 | ピート・スモーク導線の基本。既に実装済みの場合は Recommendation 扱い。 | Recommendation |
 | Lagavulin 16 | 重厚なピートとシェリー寄り導線。既に実装済みの場合は Recommendation 扱い。 | Recommendation |
-| Laphroaig 10 | アイラ・強いピートの入口。 | Registered |
+| Laphroaig 10 | アイラ・強いピートの入口。 | Recommendation |
 | Springbank 10 | 潮気・麦の厚み・複雑さの導線。既に実装済みの場合は Recommendation 扱い。 | Recommendation |
 | Longrow Peated | Springbankからピート方向へ広げる候補。 | Planned |
 

--- a/docs/SUPPORTED_BOTTLES.md
+++ b/docs/SUPPORTED_BOTTLES.md
@@ -21,7 +21,7 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 
 - Supported Bottles: 168
 - Registered Bottles: 21
-- Recommendation Implemented: 10
+- Recommendation Implemented: 11
 - Reviewed: 7
 
 ## Status Definitions
@@ -44,7 +44,7 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 | Ardbeg | Corryvreckan | Planned |
 | Lagavulin | 8 | Planned |
 | Lagavulin | 16 | Recommendation |
-| Laphroaig | 10 | Registered |
+| Laphroaig | 10 | Recommendation |
 | Laphroaig | Select | Planned |
 | Laphroaig | Quarter Cask | Planned |
 | Laphroaig | Lore | Planned |

--- a/frontend/app/data/bottle-recommendations.ts
+++ b/frontend/app/data/bottle-recommendations.ts
@@ -28,6 +28,16 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
     moodTags: ["adventurous", "quiet-night", "slow-drink"],
     sceneTags: ["bold-smoke", "solo-drink", "after-dinner"],
   },
+  laphroaig10yearold: {
+    bottleId: "laphroaig10yearold",
+    cardRecommendation:
+      "力強いスモークや潮気が印象的な一本。\n\nピートをもっと楽しみたいならArdbeg 10、\n海沿いらしい個性を少し違う形で味わうならTalisker 10もおすすめです。",
+    detailRecommendation:
+      "Laphroaig 10の魅力は、強いピートだけでなく、\n潮気や薬品感まで含めた独特の個性にあります。\n\nこの方向が好きなら、\nより力強いスモークを感じられるArdbeg 10や、\n潮気を活かしたTalisker 10へ進んでみるのも面白い選択です。\n\n逆にピートは好きだけれど少し甘さも欲しいなら、\nLagavulin 16のような重厚なタイプも候補になります。",
+    directionTags: ["peat-forward", "coastal", "medicinal", "smoky"],
+    moodTags: ["じっくり", "個性的", "夜更け"],
+    sceneTags: ["一人飲み", "バータイム", "ゆっくり飲みたい夜"],
+  },
   bowmore12yearold: {
     bottleId: "bowmore12yearold",
     cardRecommendation:

--- a/frontend/app/data/distilleries.ts
+++ b/frontend/app/data/distilleries.ts
@@ -218,6 +218,7 @@ const distillerySeeds: DistillerySeed[] = [
     region: "Islay",
     keywords: ["ラフロイグ"],
     bottleName: "Laphroaig 10 Year Old",
+    preferenceTags: ["ピート", "スモーク", "潮気", "薬品感", "アイラ"],
     tasteProfile: "薬品香を思わせる強いピート、海藻のような潮気、しっかりした煙たさ。",
     recommendedFor: "個性的で忘れにくい一本に挑戦したい人や、強いスモークが好きな人向け。",
   },


### PR DESCRIPTION
## Summary

Issue #72 / PR 1: Laphroaig 10 の finalized recommendation copy を既存 bottle slug に紐づけ、Wave 1 recommendation coverage を拡張します。

## What changed

- `frontend/app/data/bottle-recommendations.ts`: `laphroaig10yearold` の `BottleRecommendation` entry を追加
- `frontend/app/data/distilleries.ts`: Laphroaig 10 に日本語表示用 `preferenceTags` を追加
- `docs/SUPPORTED_BOTTLES.md`: Laphroaig 10 を `Registered` から `Recommendation` に更新し、Recommendation Implemented を 11 に更新
- `docs/RECOMMENDATION_ROADMAP.md`: Laphroaig 10 を `Recommendation` に更新し、Current Coverage を今回の wiring 後の数値に更新

## Laphroaig 10 slug confirmation

- Existing bottle data uses `bottleName: "Laphroaig 10 Year Old"`
- Current slug generation lowercases and strips non-alphanumeric characters
- Confirmed recommendation key/slug: `laphroaig10yearold`

## Added tags

- `directionTags`: `["peat-forward", "coastal", "medicinal", "smoky"]`
- `moodTags`: `["じっくり", "個性的", "夜更け"]`
- `sceneTags`: `["一人飲み", "バータイム", "ゆっくり飲みたい夜"]`
- `preferenceTags`: `["ピート", "スモーク", "潮気", "薬品感", "アイラ"]`

## Validation

- `npm.cmd run build` succeeded
- Confirmed `laphroaig10yearold` exists in recommendation data
- Confirmed `Laphroaig 10 Year Old` remains the source bottle name
- Confirmed `docs/SUPPORTED_BOTTLES.md` status is `Recommendation`
- Confirmed `docs/RECOMMENDATION_ROADMAP.md` status is `Recommendation`

## Screenshot

N/A - data/docs wiring only; no UI changes.
