### PR TITLE
feat(frontend): register Longrow Peated bottle

### DIFF
--- a/docs/RECOMMENDATION_ROADMAP.md
+++ b/docs/RECOMMENDATION_ROADMAP.md
@@ -17,10 +17,10 @@ Use this document to:
 
 ## Current Coverage
 
-After Laphroaig 10 recommendation wiring:
+After Longrow Peated registration:
 
 - Supported Bottles: 168
-- Registered Bottles: 21
+- Registered Bottles: 22
 - Recommendation Implemented: 11
 - Reviewed: 7
 
@@ -48,7 +48,7 @@ Highest-priority candidates for establishing Whisky-Scanner's recommendation cha
 | Lagavulin 16 | 重厚なピートとシェリー寄り導線。既に実装済みの場合は Recommendation 扱い。 | Recommendation |
 | Laphroaig 10 | アイラ・強いピートの入口。 | Recommendation |
 | Springbank 10 | 潮気・麦の厚み・複雑さの導線。既に実装済みの場合は Recommendation 扱い。 | Recommendation |
-| Longrow Peated | Springbankからピート方向へ広げる候補。 | Planned |
+| Longrow Peated | Springbankからピート方向へ広げる候補。 | Registered |
 
 ### Wave 2: Bridge Bottles
 

--- a/docs/SUPPORTED_BOTTLES.md
+++ b/docs/SUPPORTED_BOTTLES.md
@@ -20,7 +20,7 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 ## Coverage Summary
 
 - Supported Bottles: 168
-- Registered Bottles: 21
+- Registered Bottles: 22
 - Recommendation Implemented: 11
 - Reviewed: 7
 
@@ -74,7 +74,7 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 | Springbank | 10 | Recommendation |
 | Springbank | 15 | Planned |
 | Springbank | 18 | Planned |
-| Longrow | Peated | Planned |
+| Longrow | Peated | Registered |
 | Longrow | Red | Planned |
 | Hazelburn | 10 | Planned |
 | Kilkerran | 12 | Planned |

--- a/frontend/app/data/distilleries.ts
+++ b/frontend/app/data/distilleries.ts
@@ -350,7 +350,17 @@ const distillerySeeds: DistillerySeed[] = [
   },
   { name: "Inchmurrin", region: "Highland", keywords: ["インチマリン"] },
   { name: "Braeval", region: "Speyside", keywords: ["braes of glenlivet", "ブレイヴァル"] },
-  { name: "Longrow", region: "Campbeltown", keywords: ["ロングロウ"] },
+  {
+    name: "Longrow",
+    region: "Campbeltown",
+    keywords: ["ロングロウ"],
+    bottleName: "Longrow Peated",
+    preferenceTags: ["ピート", "スモーク", "潮気", "麦感", "キャンベルタウン"],
+    tasteProfile:
+      "力強いピートスモークに、潮気、麦の厚み、少しオイリーな質感が重なるキャンベルタウンらしい味わい。",
+    recommendedFor:
+      "アイラとは少し違うスモークや、麦感と潮気のある個性的な一本を試したい人向け。",
+  },
   { name: "Knockdhu", region: "Highland", keywords: ["an cnoc", "ノックドゥ"] },
   {
     name: "Yoichi",


### PR DESCRIPTION
## Summary

Issue #72 / PR 2: Longrow Peated を bottle data に正式登録し、Wave 1 Recommendation Expansion の次PRに向けた土台を作ります。

## What changed

- `frontend/app/data/distilleries.ts`: Longrow seed に `bottleName: "Longrow Peated"` を追加
- `frontend/app/data/distilleries.ts`: Longrow Peated の `preferenceTags`, `tasteProfile`, `recommendedFor` を追加
- `docs/SUPPORTED_BOTTLES.md`: `Longrow | Peated` を `Planned` から `Registered` に更新
- `docs/RECOMMENDATION_ROADMAP.md`: `Longrow Peated` を `Planned` から `Registered` に更新
- Coverage の `Registered Bottles` を `21` から `22` に更新

## Longrow Peated slug

- Existing slug generation lowercases and strips non-alphanumeric characters
- `Longrow Peated` -> `longrowpeated`

## Added preferenceTags

- `["ピート", "スモーク", "潮気", "麦感", "キャンベルタウン"]`

## Recommendation scope

- No `BottleRecommendation` entry was added
- No `cardRecommendation`, `detailRecommendation`, `directionTags`, `moodTags`, or `sceneTags` were added

## Validation

- `npm.cmd run build` succeeded
- Confirmed generated slug: `longrowpeated`
- Confirmed `frontend/.next/server/app/bottles/longrowpeated.html` exists after build
- Confirmed no `longrowpeated` entry exists in `frontend/app/data/bottle-recommendations.ts`
- Confirmed docs statuses are `Registered`

## Screenshot

N/A - data/docs registration only; no UI changes.
