### PR TITLE
feat(frontend): add Longrow Peated recommendation wiring

### DIFF
--- a/docs/RECOMMENDATION_ROADMAP.md
+++ b/docs/RECOMMENDATION_ROADMAP.md
@@ -17,11 +17,11 @@ Use this document to:
 
 ## Current Coverage
 
-After Longrow Peated registration:
+After Longrow Peated recommendation wiring:
 
 - Supported Bottles: 168
 - Registered Bottles: 22
-- Recommendation Implemented: 11
+- Recommendation Implemented: 12
 - Reviewed: 7
 
 ## Prioritization Criteria
@@ -48,7 +48,7 @@ Highest-priority candidates for establishing Whisky-Scanner's recommendation cha
 | Lagavulin 16 | 重厚なピートとシェリー寄り導線。既に実装済みの場合は Recommendation 扱い。 | Recommendation |
 | Laphroaig 10 | アイラ・強いピートの入口。 | Recommendation |
 | Springbank 10 | 潮気・麦の厚み・複雑さの導線。既に実装済みの場合は Recommendation 扱い。 | Recommendation |
-| Longrow Peated | Springbankからピート方向へ広げる候補。 | Registered |
+| Longrow Peated | Springbankからピート方向へ広げる候補。 | Recommendation |
 
 ### Wave 2: Bridge Bottles
 

--- a/docs/SUPPORTED_BOTTLES.md
+++ b/docs/SUPPORTED_BOTTLES.md
@@ -21,7 +21,7 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 
 - Supported Bottles: 168
 - Registered Bottles: 22
-- Recommendation Implemented: 11
+- Recommendation Implemented: 12
 - Reviewed: 7
 
 ## Status Definitions
@@ -74,7 +74,7 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 | Springbank | 10 | Recommendation |
 | Springbank | 15 | Planned |
 | Springbank | 18 | Planned |
-| Longrow | Peated | Registered |
+| Longrow | Peated | Recommendation |
 | Longrow | Red | Planned |
 | Hazelburn | 10 | Planned |
 | Kilkerran | 12 | Planned |

--- a/frontend/app/data/bottle-recommendations.ts
+++ b/frontend/app/data/bottle-recommendations.ts
@@ -38,6 +38,16 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
     moodTags: ["じっくり", "個性的", "夜更け"],
     sceneTags: ["一人飲み", "バータイム", "ゆっくり飲みたい夜"],
   },
+  longrowpeated: {
+    bottleId: "longrowpeated",
+    cardRecommendation:
+      "潮気や麦の厚みに、心地よいスモークが重なる一本。\nこの方向が好きならSpringbank 10で麦の個性を楽しんだり、\nArdbeg 10でさらに力強いピートへ進んでみるのもおすすめです。",
+    detailRecommendation:
+      "Longrow Peated の魅力は、\nキャンベルタウンらしい麦の厚みや潮気を残しながら、\nしっかりとスモークを感じられるところにあります。\nこの方向が好きなら、\nSpringbank 10でより複雑なバランスを楽しんだり、\nArdbeg 10でピートをさらに前面に感じるスタイルへ進むのも面白い選択です。\nまた、潮気や力強さを別の形で味わいたいなら、\nTalisker 10も候補になります。",
+    directionTags: ["peated", "coastal", "malt-forward", "campbeltown"],
+    moodTags: ["じっくり", "落ち着いた夜", "探求したい"],
+    sceneTags: ["一人飲み", "バータイム", "ゆっくり飲みたい夜"],
+  },
   bowmore12yearold: {
     bottleId: "bowmore12yearold",
     cardRecommendation:

--- a/frontend/app/data/bottle-recommendations.ts
+++ b/frontend/app/data/bottle-recommendations.ts
@@ -41,9 +41,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   longrowpeated: {
     bottleId: "longrowpeated",
     cardRecommendation:
-      "潮気や麦の厚みに、心地よいスモークが重なる一本。\nこの方向が好きならSpringbank 10で麦の個性を楽しんだり、\nArdbeg 10でさらに力強いピートへ進んでみるのもおすすめです。",
+      "潮気や麦の厚みに、心地よいスモークが重なる一本。\n\nこの方向が好きならSpringbank 10で麦の個性を楽しんだり、\n\nArdbeg 10でさらに力強いピートへ進んでみるのもおすすめです。",
     detailRecommendation:
-      "Longrow Peated の魅力は、\nキャンベルタウンらしい麦の厚みや潮気を残しながら、\nしっかりとスモークを感じられるところにあります。\nこの方向が好きなら、\nSpringbank 10でより複雑なバランスを楽しんだり、\nArdbeg 10でピートをさらに前面に感じるスタイルへ進むのも面白い選択です。\nまた、潮気や力強さを別の形で味わいたいなら、\nTalisker 10も候補になります。",
+      "Longrow Peated の魅力は、\n\nキャンベルタウンらしい麦の厚みや潮気を残しながら、\n\nしっかりとスモークを感じられるところにあります。\n\nこの方向が好きなら、\n\nSpringbank 10でより複雑なバランスを楽しんだり、\n\nArdbeg 10でピートをさらに前面に感じるスタイルへ進むのも面白い選択です。\n\nまた、潮気や力強さを別の形で味わいたいなら、\n\nTalisker 10も候補になります。",
     directionTags: ["peated", "coastal", "malt-forward", "campbeltown"],
     moodTags: ["じっくり", "落ち着いた夜", "探求したい"],
     sceneTags: ["一人飲み", "バータイム", "ゆっくり飲みたい夜"],


### PR DESCRIPTION
## Summary

Issue #72 / PR 3: Longrow Peated に finalized recommendation copy を紐づけ、Wave 1 Recommendation Expansion を完了します。

## What changed

- `frontend/app/data/bottle-recommendations.ts`: `longrowpeated` の `BottleRecommendation` entry を追加
- `docs/SUPPORTED_BOTTLES.md`: Longrow Peated を `Registered` から `Recommendation` に更新
- `docs/RECOMMENDATION_ROADMAP.md`: Wave 1 の Longrow Peated を `Recommendation` に更新
- Coverage Summary の Recommendation Implemented を `11` から `12` に更新

## Longrow Peated slug confirmation

- Existing bottle data uses `bottleName: "Longrow Peated"`
- Current slug generation lowercases and strips non-alphanumeric characters
- Confirmed recommendation key/slug: `longrowpeated`

## Recommendation added

- Added the provided `cardRecommendation` without rewriting or shortening it
- Added the provided `detailRecommendation` without rewriting or shortening it
- `directionTags`: `["peated", "coastal", "malt-forward", "campbeltown"]`
- `moodTags`: `["じっくり", "落ち着いた夜", "探求したい"]`
- `sceneTags`: `["一人飲み", "バータイム", "ゆっくり飲みたい夜"]`
- Existing `preferenceTags` were not changed

## Validation

- `npm.cmd run build` succeeded
- Confirmed generated slug: `longrowpeated`
- Confirmed `/bottles/longrowpeated` static page was generated
- Confirmed `git diff --check` passed
- Confirmed both docs statuses are `Recommendation`
- Confirmed changes are limited to recommendation data and the two requested docs

## Screenshot

N/A - data/docs wiring only; no UI changes.
