### PR TITLE
feat(frontend): expand Highland Park and Oban recommendations

### DIFF
--- a/docs/RECOMMENDATION_ROADMAP.md
+++ b/docs/RECOMMENDATION_ROADMAP.md
@@ -17,11 +17,11 @@ Use this document to:
 
 ## Current Coverage
 
-After Longrow Peated recommendation wiring:
+After Highland Park 12 and Oban 14 recommendation wiring:
 
 - Supported Bottles: 168
-- Registered Bottles: 22
-- Recommendation Implemented: 12
+- Registered Bottles: 23
+- Recommendation Implemented: 14
 - Reviewed: 7
 
 ## Prioritization Criteria
@@ -56,10 +56,10 @@ Candidates that connect peat, sherry, fruit, region cues, and drinking styles.
 
 | Bottle | Reason | Status |
 | --- | --- | --- |
-| Highland Park 12 | ピートとシェリーの橋渡し。 | Registered |
+| Highland Park 12 | ピートとシェリーの橋渡し。 | Recommendation |
 | GlenAllachie 15 | シェリー樽・濃厚甘みの導線。 | Planned |
 | Balvenie DoubleWood 12 | Speysideの甘みと樽感の入口。 | Registered |
-| Oban 14 | Highland / Coastal感の入口。 | Planned |
+| Oban 14 | Highland / Coastal感の入口。 | Recommendation |
 
 ### Wave 3: Japan Entry Points
 

--- a/docs/SUPPORTED_BOTTLES.md
+++ b/docs/SUPPORTED_BOTTLES.md
@@ -20,8 +20,8 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 ## Coverage Summary
 
 - Supported Bottles: 168
-- Registered Bottles: 22
-- Recommendation Implemented: 12
+- Registered Bottles: 23
+- Recommendation Implemented: 14
 - Reviewed: 7
 
 ## Status Definitions
@@ -98,7 +98,7 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 | Arran | Quarter Cask | Planned |
 | Arran | Sherry Cask | Planned |
 | Arran | 18 | Planned |
-| Highland Park | 12 | Registered |
+| Highland Park | 12 | Recommendation |
 | Highland Park | 15 | Planned |
 | Highland Park | 18 | Planned |
 | Highland Park | Cask Strength | Planned |
@@ -160,7 +160,7 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 | Glenmorangie | Quinta Ruban | Planned |
 | Glenmorangie | Nectar d'Or | Planned |
 | Glenmorangie | 18 | Planned |
-| Oban | 14 | Planned |
+| Oban | 14 | Recommendation |
 | Oban | Little Bay | Planned |
 | Clynelish | 14 | Planned |
 | Deanston | 12 | Planned |

--- a/frontend/app/data/bottle-recommendations.ts
+++ b/frontend/app/data/bottle-recommendations.ts
@@ -51,9 +51,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   highlandpark12yearold: {
     bottleId: "highlandpark12yearold",
     cardRecommendation:
-      "蜂蜜のような甘みと穏やかなスモークが重なる一本。\n\nシェリー系の甘さが好きならThe Macallan 12へ、\n\nもう少し潮気やピートを感じたいならTalisker 10へ進んでみるのもおすすめです。",
+      "蜂蜜のような甘みと穏やかなスモークが重なる一本。\n\nシェリー系の甘さが好きならThe Macallan 12へ、\nもう少し潮気やピートを感じたいならTalisker 10へ進んでみるのもおすすめです。",
     detailRecommendation:
-      "Highland Park 12 の魅力は、\n\n蜂蜜のような甘みやシェリー樽のニュアンスに、\n\n控えめなスモークが重なるバランスにあります。\n\nこの方向が好きなら、\n\nよりシェリーの甘みを楽しめるThe Macallan 12や、\n\n潮気とピートを少し強めに感じられるTalisker 10へ進んでみるのも面白い選択です。\n\nピートに苦手意識がある人でも、\n\n甘みとのバランスで楽しみやすい一本です。",
+      "Highland Park 12 の魅力は、\n蜂蜜のような甘みやシェリー樽のニュアンスに、\n控えめなスモークが重なるバランスにあります。\n\nこの方向が好きなら、\nよりシェリーの甘みを楽しめるThe Macallan 12や、\n潮気とピートを少し強めに感じられるTalisker 10へ進んでみるのも面白い選択です。\n\nピートに苦手意識がある人でも、\n甘みとのバランスで楽しみやすい一本です。",
     directionTags: ["balanced-peat", "sherry", "honeyed", "island"],
     moodTags: ["落ち着いた夜", "穏やか", "少し広げたい"],
     sceneTags: ["食後", "ゆっくり飲みたい夜", "バータイム"],
@@ -61,9 +61,9 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
   oban14yearold: {
     bottleId: "oban14yearold",
     cardRecommendation:
-      "海沿いらしい潮気と、やわらかな果実感のバランスが心地よい一本。\n\nTalisker 10の潮気が好きなら少し穏やかな方向として、\n\nArran 10が好きなら海沿いのニュアンスを足す一本としておすすめです。",
+      "海沿いらしい潮気と、やわらかな果実感のバランスが心地よい一本。\n\nTalisker 10の潮気が好きなら少し穏やかな方向として、\nArran 10が好きなら海沿いのニュアンスを足す一本としておすすめです。",
     detailRecommendation:
-      "Oban 14 の魅力は、\n\n強く主張しすぎない潮気と、\n\n果実感や麦のやわらかさがきれいにまとまっているところにあります。\n\nTalisker 10の海沿いらしさが好きだけれど、\n\nもう少し穏やかに楽しみたいならOban 14は良い候補です。\n\nArran 10のような飲みやすさが好きな人にも、\n\n少し潮気のある方向へ広げる一本として試しやすいと思います。",
+      "Oban 14 の魅力は、\n強く主張しすぎない潮気と、\n果実感や麦のやわらかさがきれいにまとまっているところにあります。\n\nTalisker 10の海沿いらしさが好きだけれど、\nもう少し穏やかに楽しみたいならOban 14は良い候補です。\n\nArran 10のような飲みやすさが好きな人にも、\n少し潮気のある方向へ広げる一本として試しやすいと思います。",
     directionTags: ["coastal", "balanced", "fruit-forward", "highland"],
     moodTags: ["穏やか", "落ち着いた夜", "自然体"],
     sceneTags: ["食後", "ゆっくり飲みたい夜", "初めてのバー"],

--- a/frontend/app/data/bottle-recommendations.ts
+++ b/frontend/app/data/bottle-recommendations.ts
@@ -48,6 +48,26 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
     moodTags: ["じっくり", "落ち着いた夜", "探求したい"],
     sceneTags: ["一人飲み", "バータイム", "ゆっくり飲みたい夜"],
   },
+  highlandpark12yearold: {
+    bottleId: "highlandpark12yearold",
+    cardRecommendation:
+      "蜂蜜のような甘みと穏やかなスモークが重なる一本。\n\nシェリー系の甘さが好きならThe Macallan 12へ、\n\nもう少し潮気やピートを感じたいならTalisker 10へ進んでみるのもおすすめです。",
+    detailRecommendation:
+      "Highland Park 12 の魅力は、\n\n蜂蜜のような甘みやシェリー樽のニュアンスに、\n\n控えめなスモークが重なるバランスにあります。\n\nこの方向が好きなら、\n\nよりシェリーの甘みを楽しめるThe Macallan 12や、\n\n潮気とピートを少し強めに感じられるTalisker 10へ進んでみるのも面白い選択です。\n\nピートに苦手意識がある人でも、\n\n甘みとのバランスで楽しみやすい一本です。",
+    directionTags: ["balanced-peat", "sherry", "honeyed", "island"],
+    moodTags: ["落ち着いた夜", "穏やか", "少し広げたい"],
+    sceneTags: ["食後", "ゆっくり飲みたい夜", "バータイム"],
+  },
+  oban14yearold: {
+    bottleId: "oban14yearold",
+    cardRecommendation:
+      "海沿いらしい潮気と、やわらかな果実感のバランスが心地よい一本。\n\nTalisker 10の潮気が好きなら少し穏やかな方向として、\n\nArran 10が好きなら海沿いのニュアンスを足す一本としておすすめです。",
+    detailRecommendation:
+      "Oban 14 の魅力は、\n\n強く主張しすぎない潮気と、\n\n果実感や麦のやわらかさがきれいにまとまっているところにあります。\n\nTalisker 10の海沿いらしさが好きだけれど、\n\nもう少し穏やかに楽しみたいならOban 14は良い候補です。\n\nArran 10のような飲みやすさが好きな人にも、\n\n少し潮気のある方向へ広げる一本として試しやすいと思います。",
+    directionTags: ["coastal", "balanced", "fruit-forward", "highland"],
+    moodTags: ["穏やか", "落ち着いた夜", "自然体"],
+    sceneTags: ["食後", "ゆっくり飲みたい夜", "初めてのバー"],
+  },
   bowmore12yearold: {
     bottleId: "bowmore12yearold",
     cardRecommendation:

--- a/frontend/app/data/distilleries.ts
+++ b/frontend/app/data/distilleries.ts
@@ -111,6 +111,7 @@ const distillerySeeds: DistillerySeed[] = [
     region: "Islands",
     keywords: ["ハイランドパーク"],
     bottleName: "Highland Park 12 Year Old",
+    preferenceTags: ["穏やかなピート", "シェリー", "蜂蜜", "バランス", "島もの"],
   },
   {
     name: "Auchentoshan",
@@ -338,7 +339,17 @@ const distillerySeeds: DistillerySeed[] = [
     keywords: ["allt a bhainne", "allt-a-bhainne", "アルタベーン"],
   },
   { name: "Mosstowie", region: "Speyside", keywords: ["mosstowie"] },
-  { name: "Oban", region: "Highland", keywords: ["オーバン"] },
+  {
+    name: "Oban",
+    region: "Highland",
+    keywords: ["オーバン"],
+    bottleName: "Oban 14 Year Old",
+    preferenceTags: ["潮気", "果実感", "麦感", "バランス", "ハイランド"],
+    tasteProfile:
+      "穏やかな潮気に、オレンジや洋梨を思わせる果実感、麦のやわらかな甘みが重なるバランスのよい味わい。",
+    recommendedFor:
+      "強すぎない潮気や果実感を楽しみながら、海沿いらしい個性を穏やかに味わいたい人向け。",
+  },
   {
     name: "Lagavulin",
     region: "Islay",


### PR DESCRIPTION
## Summary

Issue #76 / PR 1: Highland Park 12 と Oban 14 を Recommendation 状態へ進め、Wave 2の前半としてMacallan / TaliskerおよびArran / Talisker間の次の一本導線を追加します。

## What changed

- `frontend/app/data/bottle-recommendations.ts`
  - `highlandpark12yearold` のfinalized recommendation copyとtagsを追加
  - `oban14yearold` のfinalized recommendation copyとtagsを追加
- `frontend/app/data/distilleries.ts`
  - Highland Park 12へ明示的な日本語`preferenceTags`を追加
  - Obanの汎用`Oban Single Malt`を`Oban 14 Year Old`として明示登録
  - Oban 14の`preferenceTags`, `tasteProfile`, `recommendedFor`を追加
- `docs/SUPPORTED_BOTTLES.md`
  - Highland Park 12とOban 14を`Recommendation`へ更新
  - Registered Bottlesを22から23へ更新
  - Recommendation Implementedを12から14へ更新
- `docs/RECOMMENDATION_ROADMAP.md`
  - Wave 2の2本を`Recommendation`へ更新
  - Coverageを同じ数値へ更新

## Slug confirmation

- Highland Park 12: `highlandpark12yearold`
- Oban 14: `oban14yearold`
- 旧Oban汎用slug `obansinglemalt`は置き換え済み

## Recommendation added

- 提供された`cardRecommendation`と`detailRecommendation`を文言変更せず追加
- Highland Park 12 tags:
  - `directionTags`: `["balanced-peat", "sherry", "honeyed", "island"]`
  - `moodTags`: `["落ち着いた夜", "穏やか", "少し広げたい"]`
  - `sceneTags`: `["食後", "ゆっくり飲みたい夜", "バータイム"]`
- Oban 14 tags:
  - `directionTags`: `["coastal", "balanced", "fruit-forward", "highland"]`
  - `moodTags`: `["穏やか", "落ち着いた夜", "自然体"]`
  - `sceneTags`: `["食後", "ゆっくり飲みたい夜", "初めてのバー"]`

## Validation

- `npm.cmd run build` succeeded
- Confirmed `/bottles/highlandpark12yearold` static page was generated
- Confirmed `/bottles/oban14yearold` static page was generated
- Confirmed `/bottles/obansinglemalt` is no longer generated
- Confirmed recommendation keys match generated bottle slugs
- Confirmed both docs use consistent status and coverage values
- `git diff --check` passed

## Screenshot

N/A - data and docs changes only; no UI changes.
