### PR TITLE
feat(frontend): complete Wave 2 recommendation expansion

### DIFF
--- a/docs/RECOMMENDATION_ROADMAP.md
+++ b/docs/RECOMMENDATION_ROADMAP.md
@@ -17,11 +17,11 @@ Use this document to:
 
 ## Current Coverage
 
-After Highland Park 12 and Oban 14 recommendation wiring:
+After Wave 2 recommendation wiring:
 
 - Supported Bottles: 168
-- Registered Bottles: 23
-- Recommendation Implemented: 14
+- Registered Bottles: 24
+- Recommendation Implemented: 16
 - Reviewed: 7
 
 ## Prioritization Criteria
@@ -57,8 +57,8 @@ Candidates that connect peat, sherry, fruit, region cues, and drinking styles.
 | Bottle | Reason | Status |
 | --- | --- | --- |
 | Highland Park 12 | ピートとシェリーの橋渡し。 | Recommendation |
-| GlenAllachie 15 | シェリー樽・濃厚甘みの導線。 | Planned |
-| Balvenie DoubleWood 12 | Speysideの甘みと樽感の入口。 | Registered |
+| GlenAllachie 15 | シェリー樽・濃厚甘みの導線。 | Recommendation |
+| Balvenie DoubleWood 12 | Speysideの甘みと樽感の入口。 | Recommendation |
 | Oban 14 | Highland / Coastal感の入口。 | Recommendation |
 
 ### Wave 3: Japan Entry Points

--- a/docs/SUPPORTED_BOTTLES.md
+++ b/docs/SUPPORTED_BOTTLES.md
@@ -20,8 +20,8 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 ## Coverage Summary
 
 - Supported Bottles: 168
-- Registered Bottles: 23
-- Recommendation Implemented: 14
+- Registered Bottles: 24
+- Recommendation Implemented: 16
 - Reviewed: 7
 
 ## Status Definitions
@@ -129,7 +129,7 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 | Glenfarclas | 21 | Planned |
 | Glenfarclas | 105 | Planned |
 | GlenAllachie | 12 | Planned |
-| GlenAllachie | 15 | Planned |
+| GlenAllachie | 15 | Recommendation |
 | GlenAllachie | 10 Cask Strength | Planned |
 | The Glenlivet | 12 | Registered |
 | The Glenlivet | Founder's Reserve | Planned |
@@ -138,7 +138,7 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 | Aberlour | 12 | Registered |
 | Aberlour | 16 | Planned |
 | Aberlour | A'bunadh | Planned |
-| Balvenie | DoubleWood 12 | Registered |
+| Balvenie | DoubleWood 12 | Recommendation |
 | Balvenie | Caribbean Cask 14 | Planned |
 | Balvenie | Single Barrel 15 | Planned |
 | Balvenie | PortWood 21 | Planned |

--- a/frontend/app/data/bottle-recommendations.ts
+++ b/frontend/app/data/bottle-recommendations.ts
@@ -68,6 +68,26 @@ const bottleRecommendations: Record<string, BottleRecommendation> = {
     moodTags: ["穏やか", "落ち着いた夜", "自然体"],
     sceneTags: ["食後", "ゆっくり飲みたい夜", "初めてのバー"],
   },
+  balveniedoublewood12yearold: {
+    bottleId: "balveniedoublewood12yearold",
+    cardRecommendation:
+      "蜂蜜のような甘みと、樽由来のやわらかな香ばしさが楽しめる一本。\n\nGlenfiddich 12が好きなら少し樽感を足す方向で、\nThe Macallan 12が好きならより親しみやすい甘さとしておすすめです。",
+    detailRecommendation:
+      "Balvenie DoubleWood 12 の魅力は、\n蜂蜜のような甘みやバニラ感に、\n樽由来の香ばしさがやわらかく重なるところにあります。\n\nGlenfiddich 12の飲みやすさが好きなら、\n少し樽感や厚みを足す一本として楽しみやすいと思います。\n\nThe Macallan 12のような甘みが好きだけれど、\nもう少し肩の力を抜いて飲みたいときにも候補になります。",
+    directionTags: ["honeyed", "oak", "speyside", "smooth"],
+    moodTags: ["穏やか", "リラックス", "親しみやすい"],
+    sceneTags: ["家飲み", "食後", "ゆっくり飲みたい夜"],
+  },
+  glenallachie15yearold: {
+    bottleId: "glenallachie15yearold",
+    cardRecommendation:
+      "濃厚なシェリー感と、ドライフルーツのような甘みが印象的な一本。\n\nGlenfarclas 12が好きなら、より厚みのあるシェリー方向へ。\nThe Macallan 12が好きなら、甘みをさらに深く楽しむ一本としておすすめです。",
+    detailRecommendation:
+      "GlenAllachie 15 の魅力は、\nしっかりしたシェリー樽の甘みと、\nドライフルーツやチョコレートを思わせる濃厚さにあります。\n\nGlenfarclas 12のシェリー感が好きなら、\nより厚みと甘みを増した方向として楽しみやすい一本です。\n\nThe Macallan 12の上品な甘みが好きな人にも、\nもう少し濃く、深いシェリー系へ広げる候補になります。",
+    directionTags: ["sherry-rich", "dried-fruit", "full-bodied", "speyside"],
+    moodTags: ["じっくり", "濃厚", "夜更け"],
+    sceneTags: ["食後", "バータイム", "ゆっくり飲みたい夜"],
+  },
   bowmore12yearold: {
     bottleId: "bowmore12yearold",
     cardRecommendation:

--- a/frontend/app/data/distilleries.ts
+++ b/frontend/app/data/distilleries.ts
@@ -244,6 +244,7 @@ const distillerySeeds: DistillerySeed[] = [
     region: "Speyside",
     keywords: ["バルヴェニー"],
     bottleName: "Balvenie DoubleWood 12 Year Old",
+    preferenceTags: ["蜂蜜", "バニラ", "樽感", "甘み", "スペイサイド"],
   },
   { name: "Dailuaine", region: "Speyside", keywords: ["ダルユーイン"] },
   { name: "Ledaig", region: "Islands", keywords: ["レダイグ"] },
@@ -332,7 +333,17 @@ const distillerySeeds: DistillerySeed[] = [
   { name: "Glencraig", region: "Speyside", keywords: ["glencraig"] },
   { name: "Tormore", region: "Speyside", keywords: ["トーモア"] },
   { name: "Cardhu", region: "Speyside", keywords: ["カードゥ"] },
-  { name: "Glenallachie", region: "Speyside", keywords: ["glen allachie", "グレンアラヒー"] },
+  {
+    name: "Glenallachie",
+    region: "Speyside",
+    keywords: ["glen allachie", "グレンアラヒー"],
+    bottleName: "GlenAllachie 15 Year Old",
+    preferenceTags: ["シェリー", "ドライフルーツ", "チョコレート", "濃厚", "スペイサイド"],
+    tasteProfile:
+      "シェリー樽由来の濃厚な甘みに、レーズンのようなドライフルーツ感とチョコレートを思わせる深みが重なる味わい。",
+    recommendedFor:
+      "シェリー樽の甘みをしっかり楽しみたい人や、濃厚で厚みのある一本を食後にゆっくり味わいたい人向け。",
+  },
   {
     name: "Allt-a'Bhainne",
     region: "Speyside",


### PR DESCRIPTION
## Summary

Issue #76 / PR 2: Balvenie DoubleWood 12 と GlenAllachie 15 を Recommendation 状態へ進め、Wave 2 Recommendation Expansion を完了します。

## What changed

- `frontend/app/data/bottle-recommendations.ts`
  - `balveniedoublewood12yearold` のfinalized recommendation copyとtagsを追加
  - `glenallachie15yearold` のfinalized recommendation copyとtagsを追加
- `frontend/app/data/distilleries.ts`
  - Balvenie DoubleWood 12へ明示的な日本語`preferenceTags`を追加
  - 汎用`Glenallachie Single Malt`を`GlenAllachie 15 Year Old`として明示登録
  - GlenAllachie 15の`preferenceTags`, `tasteProfile`, `recommendedFor`を追加
- `docs/SUPPORTED_BOTTLES.md`
  - Balvenie DoubleWood 12とGlenAllachie 15を`Recommendation`へ更新
  - Registered Bottlesを23から24へ更新
  - Recommendation Implementedを14から16へ更新
- `docs/RECOMMENDATION_ROADMAP.md`
  - Wave 2の残り2本を`Recommendation`へ更新
  - Coverageを同じ数値へ更新

## Slug confirmation

- Balvenie DoubleWood 12: `balveniedoublewood12yearold`
- GlenAllachie 15: `glenallachie15yearold`
- 旧Glenallachie汎用slug `glenallachiesinglemalt`は置き換え済み

## Recommendation added

- 提供された`cardRecommendation`と`detailRecommendation`を文言変更せず追加
- 段落内は`\n`、段落間は`\n\n`で保持
- Balvenie DoubleWood 12 tags:
  - `directionTags`: `["honeyed", "oak", "speyside", "smooth"]`
  - `moodTags`: `["穏やか", "リラックス", "親しみやすい"]`
  - `sceneTags`: `["家飲み", "食後", "ゆっくり飲みたい夜"]`
- GlenAllachie 15 tags:
  - `directionTags`: `["sherry-rich", "dried-fruit", "full-bodied", "speyside"]`
  - `moodTags`: `["じっくり", "濃厚", "夜更け"]`
  - `sceneTags`: `["食後", "バータイム", "ゆっくり飲みたい夜"]`

## Validation

- `npm.cmd run build` succeeded
- Confirmed `/bottles/balveniedoublewood12yearold` static page was generated
- Confirmed `/bottles/glenallachie15yearold` static page was generated
- Confirmed `/bottles/glenallachiesinglemalt` is no longer generated
- Confirmed recommendation keys match generated bottle slugs
- Confirmed both docs use consistent status and coverage values
- `git diff --check` passed

## Screenshot

N/A - data and docs changes only; no UI changes.
