### PR TITLE
fix(frontend): render detail recommendations as paragraphs

### DIFF
--- a/frontend/app/bottles/[slug]/page.tsx
+++ b/frontend/app/bottles/[slug]/page.tsx
@@ -36,6 +36,9 @@ export default async function BottleDetailPage({ params }: BottleDetailPageProps
 
   const regionDescription = getRegionDescription(bottle.region);
   const detailRecommendation = bottle.recommendation?.detailRecommendation;
+  const detailRecommendationParagraphs = detailRecommendation
+    ? splitRecommendationParagraphs(detailRecommendation)
+    : [];
   const fallbackRecommendationReasons = detailRecommendation
     ? []
     : bottle.recommendationReasons;
@@ -76,7 +79,9 @@ export default async function BottleDetailPage({ params }: BottleDetailPageProps
           <p className="sectionKicker">Reason</p>
           <h2 id="reason-title">おすすめ理由</h2>
           {detailRecommendation ? (
-            <p>{detailRecommendation}</p>
+            detailRecommendationParagraphs.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))
           ) : (
             <ul className="reasonList">
               {fallbackRecommendationReasons.map((reason) => (
@@ -101,4 +106,11 @@ export default async function BottleDetailPage({ params }: BottleDetailPageProps
 
     </main>
   );
+}
+
+function splitRecommendationParagraphs(recommendation: string) {
+  return recommendation
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
 }


### PR DESCRIPTION
## Summary

Bottle Detail の REASON / おすすめ理由で、`detailRecommendation` の段落区切りが画面上でも読みやすく反映されるようにしました。

## What changed

- `frontend/app/bottles/[slug]/page.tsx`
  - `detailRecommendation` を `\n\n` ごとに分割し、段落ごとに `<p>` として描画するように変更しました。
  - recommendation data / cardRecommendation / 既存 recommendation 文言は変更していません。
  - fallback の `recommendationReasons` 表示は既存の `ul.reasonList` のままです。

## Validation

- `npm.cmd run build` succeeded.
- Generated Bottle Detail HTML confirms paragraph rendering for:
  - Dewar's 12: 3 paragraphs
  - Johnnie Walker Black Label: 3 paragraphs
  - Chivas Regal 12: 3 paragraphs
- Checked an existing recommendation bottle:
  - Laphroaig 10 renders multiple `<p>` blocks from existing `\n\n` breaks.
- `git diff --check` completed with line-ending warnings only.

## Screenshot

N/A
