### PR TITLE
docs: update reviewed coverage

### DIFF
--- a/docs/RECOMMENDATION_ROADMAP.md
+++ b/docs/RECOMMENDATION_ROADMAP.md
@@ -22,7 +22,7 @@ After Wave 4 Blended Scotch entry points:
 - Supported Bottles: 168
 - Registered Bottles: 29
 - Recommendation Implemented: 23
-- Reviewed: 7
+- Reviewed: 14
 
 ## Prioritization Criteria
 
@@ -67,10 +67,10 @@ Entry points for Japanese users and Japan-market familiarity.
 
 | Bottle | Reason | Status |
 | --- | --- | --- |
-| 山崎 Single Malt | 日本市場での認知度が高い入口。 | Recommendation |
-| 白州 Single Malt | 軽やかさ・ハーブ・森感の入口。 | Recommendation |
-| 余市 Single Malt | 日本のピート・厚みの入口。 | Recommendation |
-| 宮城峡 Single Malt | 果実感・やわらかさの入口。 | Recommendation |
+| 山崎 Single Malt | 日本市場での認知度が高い入口。 | Reviewed |
+| 白州 Single Malt | 軽やかさ・ハーブ・森感の入口。 | Reviewed |
+| 余市 Single Malt | 日本のピート・厚みの入口。 | Reviewed |
+| 宮城峡 Single Malt | 果実感・やわらかさの入口。 | Reviewed |
 
 ### Wave 4: Blended / Blended Malt Entry Points
 
@@ -78,9 +78,9 @@ Important candidates for users whose whisky memory starts from widely available 
 
 | Bottle | Reason | Status |
 | --- | --- | --- |
-| Johnnie Walker Black Label | 多く飲まれるブレンデッド。スモーク導線の入口。 | Recommendation |
-| Chivas Regal 12 | 甘み・飲みやすさ・Speyside導線の入口。 | Recommendation |
-| Dewar's 12 | ハイボールや食中酒導線の入口。 | Recommendation |
+| Johnnie Walker Black Label | 多く飲まれるブレンデッド。スモーク導線の入口。 | Reviewed |
+| Chivas Regal 12 | 甘み・飲みやすさ・Speyside導線の入口。 | Reviewed |
+| Dewar's 12 | ハイボールや食中酒導線の入口。 | Reviewed |
 | Monkey Shoulder | ブレンデッドモルトからSpeyside系へつなぐ入口。 | Planned |
 
 ## Operational Rules

--- a/docs/SUPPORTED_BOTTLES.md
+++ b/docs/SUPPORTED_BOTTLES.md
@@ -22,7 +22,7 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 - Supported Bottles: 168
 - Registered Bottles: 29
 - Recommendation Implemented: 23
-- Reviewed: 7
+- Reviewed: 14
 
 ## Status Definitions
 
@@ -209,12 +209,12 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 
 | Distillery | Bottle | Status |
 | --- | --- | --- |
-| 山崎 | Single Malt | Recommendation |
+| 山崎 | Single Malt | Reviewed |
 | 山崎 | 12 | Planned |
-| 白州 | Single Malt | Recommendation |
+| 白州 | Single Malt | Reviewed |
 | 白州 | 12 | Planned |
-| 余市 | Single Malt | Recommendation |
-| 宮城峡 | Single Malt | Recommendation |
+| 余市 | Single Malt | Reviewed |
+| 宮城峡 | Single Malt | Reviewed |
 | 知多 | Single Grain | Planned |
 | 響 | Japanese Harmony | Planned |
 
@@ -223,17 +223,17 @@ Initial coverage is intentionally broad. It is easier to remove lower-priority c
 | Brand | Bottle | Status |
 | --- | --- | --- |
 | Johnnie Walker | Red Label | Planned |
-| Johnnie Walker | Black Label | Recommendation |
+| Johnnie Walker | Black Label | Reviewed |
 | Johnnie Walker | Double Black | Planned |
 | Johnnie Walker | Green Label 15 | Planned |
 | Johnnie Walker | Gold Label Reserve | Planned |
 | Johnnie Walker | Blue Label | Planned |
-| Chivas Regal | 12 | Recommendation |
+| Chivas Regal | 12 | Reviewed |
 | Chivas Regal | Extra 13 | Planned |
 | Chivas Regal | Mizunara | Planned |
 | Chivas Regal | 18 | Planned |
 | Dewar's | White Label | Planned |
-| Dewar's | 12 | Recommendation |
+| Dewar's | 12 | Reviewed |
 | Dewar's | 15 | Planned |
 | Dewar's | 18 | Planned |
 | Ballantine's | Finest | Planned |


### PR DESCRIPTION
## Summary

Update reviewed status after real-device Bottle Detail checks for the Wave 3 Japanese cluster and Wave 4 Blended Scotch entry points.

## What changed

- Updated docs/SUPPORTED_BOTTLES.md Reviewed count from 7 to 14.
- Marked the following bottles as Reviewed in docs/SUPPORTED_BOTTLES.md:
  - Yamazaki Single Malt
  - Hakushu Single Malt
  - Yoichi Single Malt
  - Miyagikyo Single Malt
  - Johnnie Walker Black Label
  - Chivas Regal 12
  - Dewar's 12
- Updated docs/RECOMMENDATION_ROADMAP.md Current Coverage Reviewed count from 7 to 14.
- Marked the same Wave 3 / Wave 4 roadmap entries as Reviewed.
- Did not change recommendation copy, bottle data, UI components, Supported Bottles, Registered Bottles, Recommendation Implemented, or Reviewed scope beyond the requested 7 bottles.

## Validation

- Confirmed docs/SUPPORTED_BOTTLES.md coverage remains:
  - Supported Bottles: 168
  - Registered Bottles: 29
  - Recommendation Implemented: 23
  - Reviewed: 14
- Confirmed docs/SUPPORTED_BOTTLES.md has 14 bottle rows ending with Reviewed.
- Confirmed all 7 requested bottles are marked Reviewed in both docs/SUPPORTED_BOTTLES.md and docs/RECOMMENDATION_ROADMAP.md.
- npm.cmd run build: passed.
- git diff --check: passed.

## Screenshot

N/A - documentation-only status update.