### PR TITLE
Add canonical whisky entity reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Whisky Scanner
 
+## Machine-readable whisky entity reference
+
+The authoritative cross-project entity reference is
+`data/reference/whisky-entities.json`. It is validated with
+`cd frontend; npm run validate:reference` and may be consumed only as a
+validated, commit-pinned snapshot. See
+`docs/WHISKY_ENTITY_REFERENCE.md` for ownership, unknown-value, and internal
+reuse rules. Other repositories must not parse
+`frontend/app/data/distilleries.ts` as an integration interface.
+
 Whisky Scanner is a personal MVP for helping home whisky drinkers find their next bottle from something they already liked.
 
 The product direction is:

--- a/data/reference/whisky-entities.json
+++ b/data/reference/whisky-entities.json
@@ -1,0 +1,1700 @@
+{
+  "schema_version": 1,
+  "reference_id": "whisky-scanner-entities-v1",
+  "entries": [
+    {
+      "canonical_name": "Glenfarclas",
+      "aliases": [
+        "グレンファークラス"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenlivet",
+      "aliases": [
+        "the glenlivet",
+        "ザ グレンリベット",
+        "グレンリベット"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Bowmore",
+      "aliases": [
+        "ボウモア"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islay",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Highland Park",
+      "aliases": [
+        "ハイランドパーク"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islands",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Auchentoshan",
+      "aliases": [
+        "オーヘントッシャン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Lowland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Macduff",
+      "aliases": [
+        "glen deveron",
+        "マクダフ",
+        "グレンデヴェロン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Longmorn",
+      "aliases": [
+        "ロングモーン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Tamdhu",
+      "aliases": [
+        "タムデュー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glen Grant",
+      "aliases": [
+        "glengrant",
+        "グレングラント"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Bunnahabhain",
+      "aliases": [
+        "ブナハーブン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islay",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Tomatin",
+      "aliases": [
+        "トマーティン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Benriach",
+      "aliases": [
+        "ben riach",
+        "ベンリアック"
+      ],
+      "kind": "distillery",
+      "country": "Scotland",
+      "region": "Speyside",
+      "distillery_type": "malt"
+    },
+    {
+      "canonical_name": "Dalmore",
+      "aliases": [
+        "ダルモア"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Talisker",
+      "aliases": [
+        "タリスカー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islands",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenfiddich",
+      "aliases": [
+        "グレンフィディック"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenturret",
+      "aliases": [
+        "グレンタレット"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Scapa",
+      "aliases": [
+        "スキャパ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islands",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Inchgower",
+      "aliases": [
+        "インチガワー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glen Garioch",
+      "aliases": [
+        "glengarioch",
+        "グレンギリー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Inverleven",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "Lowland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenglassaugh",
+      "aliases": [
+        "グレングラッサ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenkinchie",
+      "aliases": [
+        "グレンキンチー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Lowland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Bruichladdich",
+      "aliases": [
+        "ブルックラディ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islay",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Macallan",
+      "aliases": [
+        "the macallan",
+        "マッカラン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Rosebank",
+      "aliases": [
+        "ローズバンク"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Lowland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Clynelish",
+      "aliases": [
+        "クライヌリッシュ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Springbank",
+      "aliases": [
+        "スプリングバンク"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Campbeltown",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Tullibardine",
+      "aliases": [
+        "タリバーディン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Laphroaig",
+      "aliases": [
+        "ラフロイグ"
+      ],
+      "kind": "distillery",
+      "country": "Scotland",
+      "region": "Islay",
+      "distillery_type": "malt"
+    },
+    {
+      "canonical_name": "Glenrothes",
+      "aliases": [
+        "グレンロセス"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Isle of Jura",
+      "aliases": [
+        "jura",
+        "ジュラ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islands",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Edradour",
+      "aliases": [
+        "エドラダワー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Ardbeg",
+      "aliases": [
+        "アードベッグ"
+      ],
+      "kind": "distillery",
+      "country": "Scotland",
+      "region": "Islay",
+      "distillery_type": "malt"
+    },
+    {
+      "canonical_name": "Tamnavulin",
+      "aliases": [
+        "タムナヴーリン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glen Moray",
+      "aliases": [
+        "glenmoray",
+        "グレンマレイ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Benrinnes",
+      "aliases": [
+        "ベンリネス"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Cragganmore",
+      "aliases": [
+        "クラガンモア"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Caperdonich",
+      "aliases": [
+        "キャパドニック"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Linkwood",
+      "aliases": [
+        "リンクウッド"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Balvenie",
+      "aliases": [
+        "バルヴェニー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Dailuaine",
+      "aliases": [
+        "ダルユーイン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Ledaig",
+      "aliases": [
+        "レダイグ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islands",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Tobermory",
+      "aliases": [
+        "トバモリー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islands",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Port Ellen",
+      "aliases": [
+        "ポートエレン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islay",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Craigellachie",
+      "aliases": [
+        "クライゲラキ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Dallas Dhu",
+      "aliases": [
+        "dallasdhu",
+        "ダラスデュー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenlossie",
+      "aliases": [
+        "グレンロッシー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Benromach",
+      "aliases": [
+        "ベンロマック"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Balmenach",
+      "aliases": [
+        "バルメナック"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "St Magdalene",
+      "aliases": [
+        "saint magdalene",
+        "セントマグダレン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Lowland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Bladnoch",
+      "aliases": [
+        "ブラドノック"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Lowland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Bushmills",
+      "aliases": [
+        "ブッシュミルズ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Northern Ireland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Old Pulteney",
+      "aliases": [
+        "oldpulteney",
+        "オールドプルトニー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Caol Ila",
+      "aliases": [
+        "caolila",
+        "カリラ"
+      ],
+      "kind": "distillery",
+      "country": "Scotland",
+      "region": "Islay",
+      "distillery_type": "malt"
+    },
+    {
+      "canonical_name": "Aberlour",
+      "aliases": [
+        "アベラワー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Brackla",
+      "aliases": [
+        "royal brackla",
+        "ロイヤルブラックラ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Coleburn",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glen Mhor",
+      "aliases": [
+        "glenmhor"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Strathisla",
+      "aliases": [
+        "ストラスアイラ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Teaninich",
+      "aliases": [
+        "ティーニニック"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Aberfeldy",
+      "aliases": [
+        "アバフェルディ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Brora",
+      "aliases": [
+        "ブローラ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenlochy",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glentauchers",
+      "aliases": [
+        "グレントファース"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Mannochmore",
+      "aliases": [
+        "マノックモア"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Imperial",
+      "aliases": [
+        "インペリアル"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Ardmore",
+      "aliases": [
+        "アードモア"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Banff",
+      "aliases": [
+        "バンフ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Blair Athol",
+      "aliases": [
+        "blairathol",
+        "ブレアソール"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glen Albyn",
+      "aliases": [
+        "glenalbyn"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Balblair",
+      "aliases": [
+        "バルブレア"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenburgie",
+      "aliases": [
+        "グレンバーギー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Miltonduff",
+      "aliases": [
+        "ミルトンダフ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Aultmore",
+      "aliases": [
+        "オルトモア"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "North Port",
+      "aliases": [
+        "northport"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenury Royal",
+      "aliases": [
+        "glenuryroyal"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Mortlach",
+      "aliases": [
+        "モートラック"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glen Ord",
+      "aliases": [
+        "glenord",
+        "グレンオード"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Ben Nevis",
+      "aliases": [
+        "bennevis",
+        "ベンネヴィス"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Deanston",
+      "aliases": [
+        "ディーンストン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glen Spey",
+      "aliases": [
+        "glenspey"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glen Keith",
+      "aliases": [
+        "glenkeith",
+        "グレンキース"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glencadam",
+      "aliases": [
+        "グレンカダム"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Convalmore",
+      "aliases": [
+        "コンバルモア"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glendullan",
+      "aliases": [
+        "グレンダラン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glen Elgin",
+      "aliases": [
+        "glenelgin",
+        "グレンエルギン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenesk",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Millburn",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Speyburn",
+      "aliases": [
+        "スペイバーン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Tomintoul",
+      "aliases": [
+        "トミントール"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Pittyvaich",
+      "aliases": [
+        "ピティヴェアック"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Dufftown",
+      "aliases": [
+        "ダフタウン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Lochside",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glen Scotia",
+      "aliases": [
+        "glenscotia",
+        "グレンスコシア"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Campbeltown",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Fettercairn",
+      "aliases": [
+        "フェッターケアン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Auchroisk",
+      "aliases": [
+        "オスロスク"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glendronach",
+      "aliases": [
+        "glen dronach",
+        "グレンドロナック"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Littlemill",
+      "aliases": [
+        "リトルミル"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Lowland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Lomond (Inverleven)",
+      "aliases": [
+        "lomond"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Lowland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenugie",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Strathmill",
+      "aliases": [
+        "ストラスミル"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Knockando",
+      "aliases": [
+        "ノッカンドゥ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Dalwhinnie",
+      "aliases": [
+        "ダルウィニー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Royal Lochnagar",
+      "aliases": [
+        "royallochnagar",
+        "ロイヤルロッホナガー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glencraig",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Tormore",
+      "aliases": [
+        "トーモア"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Cardhu",
+      "aliases": [
+        "カードゥ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "GlenAllachie",
+      "aliases": [
+        "glen allachie",
+        "グレンアラヒー"
+      ],
+      "kind": "distillery",
+      "country": "Scotland",
+      "region": "Speyside",
+      "distillery_type": "malt"
+    },
+    {
+      "canonical_name": "Allt-a'Bhainne",
+      "aliases": [
+        "allt a bhainne",
+        "allt-a-bhainne",
+        "アルタベーン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Mosstowie",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Oban",
+      "aliases": [
+        "オーバン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Lagavulin",
+      "aliases": [
+        "ラガヴーリン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islay",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Inchmurrin",
+      "aliases": [
+        "インチマリン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Braeval",
+      "aliases": [
+        "braes of glenlivet",
+        "ブレイヴァル"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Speyside",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Longrow",
+      "aliases": [
+        "ロングロウ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Campbeltown",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Knockdhu",
+      "aliases": [
+        "an cnoc",
+        "ノックドゥ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Yoichi",
+      "aliases": [
+        "余市"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Japan",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Cooley",
+      "aliases": [
+        "クーリー"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Ireland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Connemara",
+      "aliases": [
+        "カネマラ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Ireland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Yamazaki",
+      "aliases": [
+        "山崎"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Japan",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Hakushu",
+      "aliases": [
+        "白州"
+      ],
+      "kind": "distillery",
+      "country": "Japan",
+      "region": "Japan",
+      "distillery_type": "malt"
+    },
+    {
+      "canonical_name": "Isle of Arran",
+      "aliases": [
+        "arran",
+        "アラン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islands",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Croftengea",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glengoyne",
+      "aliases": [
+        "グレンゴイン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Miyagikyo",
+      "aliases": [
+        "宮城峡"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Japan",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Johnnie Walker",
+      "aliases": [
+        "johnny walker",
+        "ジョニーウォーカー"
+      ],
+      "kind": "brand",
+      "country": null,
+      "region": "Blended Scotch",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Chivas Regal",
+      "aliases": [
+        "chivas",
+        "シーバスリーガル"
+      ],
+      "kind": "brand",
+      "country": null,
+      "region": "Blended Scotch",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Dewar's",
+      "aliases": [
+        "dewars",
+        "デュワーズ"
+      ],
+      "kind": "brand",
+      "country": null,
+      "region": "Blended Scotch",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glenmorangie",
+      "aliases": [
+        "グレンモーレンジィ"
+      ],
+      "kind": "distillery",
+      "country": "Scotland",
+      "region": "Highland",
+      "distillery_type": "malt"
+    },
+    {
+      "canonical_name": "Hazelburn",
+      "aliases": [
+        "ヘーゼルバーン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Campbeltown",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Port Charlotte",
+      "aliases": [
+        "ポートシャーロット"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Islay",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Penderyn",
+      "aliases": [
+        "ペンダーリン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Wales",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Kilchoman",
+      "aliases": [
+        "キルホーマン"
+      ],
+      "kind": "distillery",
+      "country": "Scotland",
+      "region": "Islay",
+      "distillery_type": "malt"
+    },
+    {
+      "canonical_name": "Chichibu",
+      "aliases": [
+        "秩父",
+        "イチローズモルト"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Japan",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Hanyu",
+      "aliases": [
+        "羽生"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Japan",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Karuizawa",
+      "aliases": [
+        "軽井沢"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Japan",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Westland",
+      "aliases": [
+        "ウェストランド"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Washington",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Paul John",
+      "aliases": [
+        "pauljohn",
+        "ポールジョン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "India",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Loch Lomond",
+      "aliases": [
+        "lochlomond",
+        "ロッホローモンド"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Eden Mill",
+      "aliases": [
+        "edenmill"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Lowland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "St George's",
+      "aliases": [
+        "st georges",
+        "st george",
+        "セントジョージ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "England",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Nantou",
+      "aliases": [
+        "ナントウ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Taiwan",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Kavalan",
+      "aliases": [
+        "カバラン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Taiwan",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Balcones",
+      "aliases": [
+        "バルコンズ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Texas",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Fary Lochan",
+      "aliases": [
+        "farylochan"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Denmark",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Breuckelen",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "New York",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Copperworks Alba",
+      "aliases": [
+        "copperworks",
+        "alba"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Washington",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "High Coast",
+      "aliases": [
+        "highcoast",
+        "ハイコースト"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Sweden",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Smogen",
+      "aliases": [
+        "smögen",
+        "スモーゲン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Sweden",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Cotswolds",
+      "aliases": [
+        "コッツウォルズ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "England",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Archie Rose",
+      "aliases": [
+        "archierose",
+        "アーチーローズ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Australia",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Starward",
+      "aliases": [
+        "スターワード"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Australia",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Ardnamurchan",
+      "aliases": [
+        "アードナムルッカン"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Highland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "West Cork",
+      "aliases": [
+        "westcork",
+        "ウエストコーク"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Ireland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Mackmyra",
+      "aliases": [
+        "マックミラ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Sweden",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Shelter Point",
+      "aliases": [
+        "shelterpoint"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Canada",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Thy",
+      "aliases": [
+        "thy whisky"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Denmark",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Mosgaard",
+      "aliases": [],
+      "kind": "distillery",
+      "country": null,
+      "region": "Denmark",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Milk & Honey",
+      "aliases": [
+        "milk and honey",
+        "m&h",
+        "m h"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Israel",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Glasgow Distillery",
+      "aliases": [
+        "glasgow"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Scotland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Warenghem (Armorik)",
+      "aliases": [
+        "warenghem",
+        "armorik"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "France",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Yuza",
+      "aliases": [
+        "遊佐"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Japan",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Shinshu",
+      "aliases": [
+        "信州",
+        "駒ヶ岳"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Japan",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Tsunuki",
+      "aliases": [
+        "津貫"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Japan",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Nc'Nean",
+      "aliases": [
+        "ncnean",
+        "nc nean"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Scotland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Raasay",
+      "aliases": [
+        "ラッセイ"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Scotland",
+      "distillery_type": "unknown"
+    },
+    {
+      "canonical_name": "Isle of Harris",
+      "aliases": [
+        "harris",
+        "ハリス"
+      ],
+      "kind": "distillery",
+      "country": null,
+      "region": "Scotland",
+      "distillery_type": "unknown"
+    }
+  ]
+}

--- a/docs/WHISKY_ENTITY_REFERENCE.md
+++ b/docs/WHISKY_ENTITY_REFERENCE.md
@@ -1,0 +1,29 @@
+# Whisky entity reference
+
+`data/reference/whisky-entities.json` is the machine-readable source of truth for
+whisky entities maintained by Whisky-Scanner. `frontend/app/data/distilleries.ts`
+remains the current UI data source until a later UI migration, but other
+projects must consume the JSON reference rather than parse the TypeScript file.
+
+The reference may be copied as a validated, commit-pinned snapshot by other
+projects owned by the same repository owner. Consumers must record the source
+repository, commit SHA, `reference_id`, and `schema_version`. This is an
+internal data reuse policy and does not set a license for the rest of the
+project.
+
+Unknown country or production type values remain `null` or `unknown`; they must
+not be inferred from region names or UI bottle defaults. Only `kind=distillery`
+entries are eligible for distillery-based enrichment in consumers.
+
+Validate changes before opening a pull request:
+
+```powershell
+cd frontend
+npm run validate:reference
+npm test
+npm run build
+```
+
+Updates are made through a feature branch and pull request. The validation
+command rejects unsupported schemas, duplicate canonical names, alias
+collisions, whitespace errors, and invalid kind/type combinations.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev -H 0.0.0.0 -p 3000",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p 3000",
+    "validate:reference": "node scripts/validate-whisky-entities.mjs",
+    "test": "npm run validate:reference && node --test scripts/validate-whisky-entities.test.mjs"
   },
   "dependencies": {
     "@google-cloud/vision": "^5.3.6",

--- a/frontend/scripts/validate-whisky-entities.mjs
+++ b/frontend/scripts/validate-whisky-entities.mjs
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { pathToFileURL } from "node:url";
+
+export const KINDS = new Set(["distillery", "brand", "unknown"]);
+export const DISTILLERY_TYPES = new Set(["malt", "grain", "mixed", "unknown"]);
+
+function normalized(value) {
+  return value.normalize("NFKC").toLocaleLowerCase("en-US");
+}
+
+function cleanString(value, label, { nullable = false } = {}) {
+  if (nullable && value === null) return;
+  if (typeof value !== "string" || !value || value !== value.trim()) {
+    throw new Error(`${label} must be a non-empty trimmed string${nullable ? " or null" : ""}`);
+  }
+}
+
+export function validateWhiskyEntities(value) {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.keys(value).sort().join(",") !== "entries,reference_id,schema_version"
+  ) {
+    throw new Error("reference document has an invalid structure");
+  }
+  if (value.schema_version !== 1) throw new Error("unsupported schema_version");
+  cleanString(value.reference_id, "reference_id");
+  if (!Array.isArray(value.entries) || value.entries.length === 0) {
+    throw new Error("entries must be a non-empty array");
+  }
+
+  const canonicalOwners = new Map();
+  const aliasOwners = new Map();
+  for (const [index, entry] of value.entries.entries()) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`entry ${index} has an invalid structure`);
+    }
+    cleanString(entry.canonical_name, `entry ${index} canonical_name`);
+    const canonical = normalized(entry.canonical_name);
+    if (canonicalOwners.has(canonical)) {
+      throw new Error(`canonical name collision: ${entry.canonical_name}`);
+    }
+    canonicalOwners.set(canonical, entry.canonical_name);
+  }
+  for (const [index, entry] of value.entries.entries()) {
+    if (
+      !entry ||
+      typeof entry !== "object" ||
+      Array.isArray(entry) ||
+      Object.keys(entry).sort().join(",") !==
+        "aliases,canonical_name,country,distillery_type,kind,region"
+    ) {
+      throw new Error(`entry ${index} has an invalid structure`);
+    }
+    cleanString(entry.canonical_name, `entry ${index} canonical_name`);
+    if (!Array.isArray(entry.aliases)) throw new Error(`entry ${index} aliases must be an array`);
+    if (!KINDS.has(entry.kind)) throw new Error(`entry ${index} kind is invalid`);
+    if (!DISTILLERY_TYPES.has(entry.distillery_type)) {
+      throw new Error(`entry ${index} distillery_type is invalid`);
+    }
+    cleanString(entry.country, `entry ${index} country`, { nullable: true });
+    cleanString(entry.region, `entry ${index} region`, { nullable: true });
+    if (entry.kind !== "distillery" && entry.distillery_type !== "unknown") {
+      throw new Error(`entry ${index} non-distillery cannot declare a distillery type`);
+    }
+
+    const canonical = normalized(entry.canonical_name);
+
+    const localAliases = new Set();
+    for (const alias of entry.aliases) {
+      cleanString(alias, `entry ${index} alias`);
+      const key = normalized(alias);
+      if (key === canonical || localAliases.has(key)) {
+        throw new Error(`alias collision in ${entry.canonical_name}: ${alias}`);
+      }
+      if (canonicalOwners.has(key) || aliasOwners.has(key)) {
+        throw new Error(`global alias collision: ${alias}`);
+      }
+      localAliases.add(key);
+      aliasOwners.set(key, entry.canonical_name);
+    }
+  }
+  return value;
+}
+
+export function loadAndValidate(referencePath) {
+  return validateWhiskyEntities(JSON.parse(fs.readFileSync(referencePath, "utf8")));
+}
+
+const isMain = process.argv[1] &&
+  pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+if (isMain) {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const referencePath = path.resolve(here, "../../data/reference/whisky-entities.json");
+  const value = loadAndValidate(referencePath);
+  process.stdout.write(
+    JSON.stringify({
+      result: "reference_valid",
+      entries: value.entries.length,
+      distilleries: value.entries.filter((entry) => entry.kind === "distillery").length,
+      brands: value.entries.filter((entry) => entry.kind === "brand").length,
+      unknown: value.entries.filter((entry) => entry.kind === "unknown").length,
+    }) + "\n",
+  );
+}

--- a/frontend/scripts/validate-whisky-entities.test.mjs
+++ b/frontend/scripts/validate-whisky-entities.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { validateWhiskyEntities } from "./validate-whisky-entities.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const referencePath = path.resolve(here, "../../data/reference/whisky-entities.json");
+const reference = JSON.parse(fs.readFileSync(referencePath, "utf8"));
+
+function clone() {
+  return structuredClone(reference);
+}
+
+test("the migrated reference is valid and retains 167 entities", () => {
+  const value = validateWhiskyEntities(clone());
+  assert.equal(value.entries.length, 167);
+});
+
+test("priority distilleries have confirmed metadata", () => {
+  const byName = new Map(reference.entries.map((entry) => [entry.canonical_name, entry]));
+  const expected = {
+    "Caol Ila": ["Scotland", "Islay"],
+    Glenmorangie: ["Scotland", "Highland"],
+    Kilchoman: ["Scotland", "Islay"],
+    GlenAllachie: ["Scotland", "Speyside"],
+    Ardbeg: ["Scotland", "Islay"],
+    Laphroaig: ["Scotland", "Islay"],
+    Hakushu: ["Japan", "Japan"],
+    Benriach: ["Scotland", "Speyside"],
+  };
+  for (const [name, [country, region]] of Object.entries(expected)) {
+    const entry = byName.get(name);
+    assert.ok(entry, name);
+    assert.equal(entry.kind, "distillery", name);
+    assert.equal(entry.country, country, name);
+    assert.equal(entry.region, region, name);
+    assert.equal(entry.distillery_type, "malt", name);
+  }
+  assert.equal(byName.has("Meikle Tòir"), false);
+  for (const name of ["Johnnie Walker", "Chivas Regal", "Dewar's"]) {
+    assert.equal(byName.get(name)?.kind, "brand", name);
+    assert.equal(byName.get(name)?.distillery_type, "unknown", name);
+  }
+});
+
+test("canonical, alias, and kind/type collisions are rejected", () => {
+  const duplicate = clone();
+  duplicate.entries[1].canonical_name = duplicate.entries[0].canonical_name;
+  assert.throws(() => validateWhiskyEntities(duplicate), /canonical name collision/);
+
+  const alias = clone();
+  alias.entries[1].aliases.push(alias.entries[0].canonical_name);
+  assert.throws(() => validateWhiskyEntities(alias), /global alias collision/);
+
+  const brandType = clone();
+  const brand = brandType.entries.find((entry) => entry.kind === "brand");
+  brand.distillery_type = "malt";
+  assert.throws(() => validateWhiskyEntities(brandType), /non-distillery/);
+});

--- a/schemas/whisky-entities.schema.json
+++ b/schemas/whisky-entities.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/takatoshi0161/Whisky-Scanner/schemas/whisky-entities.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "reference_id", "entries"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "reference_id": { "type": "string", "minLength": 1, "pattern": "^\\S(?:.*\\S)?$" },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["canonical_name", "aliases", "kind", "country", "region", "distillery_type"],
+        "properties": {
+          "canonical_name": { "type": "string", "minLength": 1, "pattern": "^\\S(?:.*\\S)?$" },
+          "aliases": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "type": "string", "minLength": 1, "pattern": "^\\S(?:.*\\S)?$" }
+          },
+          "kind": { "enum": ["distillery", "brand", "unknown"] },
+          "country": {
+            "oneOf": [
+              { "type": "null" },
+              { "type": "string", "minLength": 1, "pattern": "^\\S(?:.*\\S)?$" }
+            ]
+          },
+          "region": {
+            "oneOf": [
+              { "type": "null" },
+              { "type": "string", "minLength": 1, "pattern": "^\\S(?:.*\\S)?$" }
+            ]
+          },
+          "distillery_type": { "enum": ["malt", "grain", "mixed", "unknown"] }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "kind": { "not": { "const": "distillery" } } } },
+            "then": { "properties": { "distillery_type": { "const": "unknown" } } }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Migrate the existing 167 whisky entities into a canonical machine-readable reference.
- Classify 164 entries as distilleries and 3 as brands.
- Manage canonical name, aliases, kind, country, region, and distillery type.
- Preserve unknown values as `null` or `unknown` without inference.
- Add schema validation, normalized collision checks, tests, and internal reuse guidance.
- Confirm metadata for the priority distilleries used by Whisky-Collection.

## Validation

- `npm test`: 3 tests passed
- `npm run build`: production build passed (171 generated pages)
- Reference validation: 167 entries, 164 distilleries, 3 brands
- `git diff --check`: passed

## Downstream

Whisky-Collection will generate a validated, offline snapshot pinned to commit `dbe092b1cb8a2b58fdb2bed1a1298075c97a369e`.